### PR TITLE
Add ability to track input values that match expressions

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -117,7 +117,7 @@
         <module name="StringLiteralEquality"/>
         <module name="NoFinalizer"/>
         <module name="PackageDeclaration"/>
-        <module name="ReturnCount"/>
+        <!--<module name="ReturnCount"/>-->
         <!--module name="DeclarationOrder"/-->
         <module name="ExplicitInitialization"/>
         <module name="DefaultComesLast"/>

--- a/freebee-bench/src/main/java/com/amobee/freebee/bench/BenchmarkRunner.java
+++ b/freebee-bench/src/main/java/com/amobee/freebee/bench/BenchmarkRunner.java
@@ -25,11 +25,12 @@ public class BenchmarkRunner
     private static final Logger logger = LoggerFactory.getLogger(BenchmarkRunner.class);
 
     // TODO externalize this configuration. For now, change this values in order to configure the benchmark
-    private static final int INPUT_COUNT = 5_000;
-    private static final int MAX_VALUES_PER_INPUT = 100;
-    private static final int EXPRESSION_COUNT = 1_000;
-    private static final int MAX_EXPRESSION_WIDTH = 100;
-    private static final int MAX_EXPRESSION_DEPTH = 5;
+    private static final int INPUT_COUNT = 1_000;
+    private static final int MAX_VALUES_PER_INPUT = 3_000;
+    private static final int EXPRESSION_COUNT = 6_500;
+    private static final int MAX_PREDICATES_PER_EXPRESSION = 5;
+    private static final int MAX_VALUES_PER_PREDICATE = 1_000;
+    private static final int MAX_EXPRESSION_DEPTH = 10;
     private static final boolean INPUT_TRACING_ENABLED = false;
     private static final long RANDOM_SEED = 14888790436548L;
 
@@ -43,7 +44,8 @@ public class BenchmarkRunner
                 new RandomBenchmarkConfigurationProperties()
                         .withRandomSeed(RANDOM_SEED)
                         .withMaxDepth(MAX_EXPRESSION_DEPTH)
-                        .withMaxWidth(MAX_EXPRESSION_WIDTH)
+                        .withMaxPredicatesPerExpression(MAX_PREDICATES_PER_EXPRESSION)
+                        .withMaxValuesPerPredicate(MAX_VALUES_PER_PREDICATE)
                         .withMaxInputValues(MAX_VALUES_PER_INPUT)
                         .withInputTracingEnabled(INPUT_TRACING_ENABLED);
 

--- a/freebee-bench/src/main/java/com/amobee/freebee/bench/BenchmarkRunner.java
+++ b/freebee-bench/src/main/java/com/amobee/freebee/bench/BenchmarkRunner.java
@@ -30,6 +30,7 @@ public class BenchmarkRunner
     private static final int EXPRESSION_COUNT = 1_000;
     private static final int MAX_EXPRESSION_WIDTH = 100;
     private static final int MAX_EXPRESSION_DEPTH = 5;
+    private static final boolean INPUT_TRACING_ENABLED = false;
     private static final long RANDOM_SEED = 14888790436548L;
 
     private BenchmarkRunner() {}
@@ -43,7 +44,8 @@ public class BenchmarkRunner
                         .withRandomSeed(RANDOM_SEED)
                         .withMaxDepth(MAX_EXPRESSION_DEPTH)
                         .withMaxWidth(MAX_EXPRESSION_WIDTH)
-                        .withMaxInputValues(MAX_VALUES_PER_INPUT);
+                        .withMaxInputValues(MAX_VALUES_PER_INPUT)
+                        .withInputTracingEnabled(INPUT_TRACING_ENABLED);
 
         final BenchmarkConfiguration configuration = new RandomBenchmarkConfiguration(expressionGeneratorProperties);
 

--- a/freebee-bench/src/main/java/com/amobee/freebee/bench/random/RandomBenchmarkConfigurationProperties.java
+++ b/freebee-bench/src/main/java/com/amobee/freebee/bench/random/RandomBenchmarkConfigurationProperties.java
@@ -4,11 +4,15 @@ public class RandomBenchmarkConfigurationProperties
 {
     private static final int DEFAULT_MAX_EXPRESSION_DEPTH = 3;
     private static final int DEFAULT_MAX_EXPRESSION_WIDTH = 1000;
+    private static final int DEFAULT_MAX_PREDICATES = 5;
+    private static final int DEFAULT_MAX_VALUES_PER_PREDICATE = 1000;
     private static final int DEFAULT_MAX_INPUT_VALUES = 100;
     private static final boolean DEFAULT_TRACKING_ENABLED = true;
 
     private Long randomSeed;
     private int maxDepth = DEFAULT_MAX_EXPRESSION_DEPTH;
+    private int maxPredicatesPerExpression = DEFAULT_MAX_PREDICATES;
+    private int maxValuesPerPredicate = DEFAULT_MAX_VALUES_PER_PREDICATE;
     private int maxWidth = DEFAULT_MAX_EXPRESSION_WIDTH;
     private int maxInputValues = DEFAULT_MAX_INPUT_VALUES;
     private boolean inputTrackingEnabled = DEFAULT_TRACKING_ENABLED;
@@ -61,6 +65,38 @@ public class RandomBenchmarkConfigurationProperties
         return this;
     }
 
+    public int getMaxPredicatesPerExpression()
+    {
+        return this.maxPredicatesPerExpression;
+    }
+
+    public void setMaxPredicatesPerExpression(final int maxPredicatesPerExpression)
+    {
+        this.maxPredicatesPerExpression = maxPredicatesPerExpression;
+    }
+
+    public RandomBenchmarkConfigurationProperties withMaxPredicatesPerExpression(final int maxPredicatesPerExpression)
+    {
+        this.maxPredicatesPerExpression = maxPredicatesPerExpression;
+        return this;
+    }
+
+    public int getMaxValuesPerPredicate()
+    {
+        return this.maxValuesPerPredicate;
+    }
+
+    public void setMaxValuesPerPredicate(final int maxValuesPerPredicate)
+    {
+        this.maxValuesPerPredicate = maxValuesPerPredicate;
+    }
+
+    public RandomBenchmarkConfigurationProperties withMaxValuesPerPredicate(final int maxValuesPerPredicate)
+    {
+        this.maxValuesPerPredicate = maxValuesPerPredicate;
+        return this;
+    }
+
     public int getMaxInputValues()
     {
         return this.maxInputValues;
@@ -97,11 +133,13 @@ public class RandomBenchmarkConfigurationProperties
     public String toString()
     {
         return "RandomBenchmarkConfigurationProperties{" +
-                "randomSeed=" + this.randomSeed +
-                ", maxDepth=" + this.maxDepth +
-                ", maxWidth=" + this.maxWidth +
-                ", maxInputValues=" + this.maxInputValues +
-                ", inputTracingEnabled=" + this.inputTrackingEnabled +
+                "randomSeed=" + randomSeed +
+                ", maxDepth=" + maxDepth +
+                ", maxPredicatesPerExpression=" + maxPredicatesPerExpression +
+                ", maxValuesPerPredicate=" + maxValuesPerPredicate +
+                ", maxWidth=" + maxWidth +
+                ", maxInputValues=" + maxInputValues +
+                ", inputTrackingEnabled=" + inputTrackingEnabled +
                 '}';
     }
 }

--- a/freebee-bench/src/main/java/com/amobee/freebee/bench/random/RandomBenchmarkConfigurationProperties.java
+++ b/freebee-bench/src/main/java/com/amobee/freebee/bench/random/RandomBenchmarkConfigurationProperties.java
@@ -5,11 +5,13 @@ public class RandomBenchmarkConfigurationProperties
     private static final int DEFAULT_MAX_EXPRESSION_DEPTH = 3;
     private static final int DEFAULT_MAX_EXPRESSION_WIDTH = 1000;
     private static final int DEFAULT_MAX_INPUT_VALUES = 100;
+    private static final boolean DEFAULT_TRACKING_ENABLED = true;
 
     private Long randomSeed;
     private int maxDepth = DEFAULT_MAX_EXPRESSION_DEPTH;
     private int maxWidth = DEFAULT_MAX_EXPRESSION_WIDTH;
     private int maxInputValues = DEFAULT_MAX_INPUT_VALUES;
+    private boolean inputTrackingEnabled = DEFAULT_TRACKING_ENABLED;
 
     public Long getRandomSeed()
     {
@@ -75,6 +77,22 @@ public class RandomBenchmarkConfigurationProperties
         return this;
     }
 
+    public boolean isInputTrackingEnabled()
+    {
+        return this.inputTrackingEnabled;
+    }
+
+    public void setInputTrackingEnabled(final boolean inputTrackingEnabled)
+    {
+        this.inputTrackingEnabled = inputTrackingEnabled;
+    }
+
+    public RandomBenchmarkConfigurationProperties withInputTracingEnabled(final boolean tracingEnabled)
+    {
+        this.inputTrackingEnabled = tracingEnabled;
+        return this;
+    }
+
     @Override
     public String toString()
     {
@@ -83,6 +101,7 @@ public class RandomBenchmarkConfigurationProperties
                 ", maxDepth=" + this.maxDepth +
                 ", maxWidth=" + this.maxWidth +
                 ", maxInputValues=" + this.maxInputValues +
+                ", inputTracingEnabled=" + this.inputTrackingEnabled +
                 '}';
     }
 }

--- a/freebee-bench/src/main/java/com/amobee/freebee/bench/random/RandomInputGenerator.java
+++ b/freebee-bench/src/main/java/com/amobee/freebee/bench/random/RandomInputGenerator.java
@@ -3,6 +3,7 @@ package com.amobee.freebee.bench.random;
 import com.amobee.freebee.bench.DataTypeConfigurer;
 import com.amobee.freebee.bench.DataValueProvider;
 import com.amobee.freebee.bench.InputGenerator;
+import com.amobee.freebee.bench.range.Range;
 import com.amobee.freebee.config.BEDataTypeConfig;
 import com.amobee.freebee.evaluator.evaluator.BEByteInputAttributeCategory;
 import com.amobee.freebee.evaluator.evaluator.BEDoubleInputAttributeCategory;
@@ -10,7 +11,6 @@ import com.amobee.freebee.evaluator.evaluator.BEInput;
 import com.amobee.freebee.evaluator.evaluator.BEIntInputAttributeCategory;
 import com.amobee.freebee.evaluator.evaluator.BELongInputAttributeCategory;
 import com.amobee.freebee.evaluator.evaluator.BEStringInputAttributeCategory;
-import com.amobee.freebee.bench.range.Range;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -111,6 +111,10 @@ public class RandomInputGenerator implements InputGenerator
                 case STRING:
                     final BEStringInputAttributeCategory stringInputCategory = input.getOrCreateStringCategory(category);
                     stringInputCategory.setTrackingEnabled(this.inputTrackingEnabled);
+                    if ("domain".equalsIgnoreCase(category))
+                    {
+                        stringInputCategory.setTrackingEnabled(true);
+                    }
                     values.forEach(stringInputCategory::add);
                     break;
                 default:

--- a/freebee-bench/src/main/java/com/amobee/freebee/bench/random/RandomInputGenerator.java
+++ b/freebee-bench/src/main/java/com/amobee/freebee/bench/random/RandomInputGenerator.java
@@ -28,6 +28,7 @@ public class RandomInputGenerator implements InputGenerator
     private final Random random;
     private final int maxCategories;
     private final int maxValues;
+    private final boolean inputTrackingEnabled;
 
     public RandomInputGenerator(
             final RandomBenchmarkConfigurationProperties properties,
@@ -37,6 +38,7 @@ public class RandomInputGenerator implements InputGenerator
         this.dataTypeConfigurer = dataValueProvider.getDataTypeConfigurer();
 
         this.random = properties.getRandomSeed() != null ? new Random(properties.getRandomSeed()) : new Random();
+        this.inputTrackingEnabled = properties.isInputTrackingEnabled();
         this.maxValues = properties.getMaxInputValues();
         // TODO allow these values to be configured externally
         this.maxCategories = DEFAULT_MAX_CATEGORIES;
@@ -88,22 +90,27 @@ public class RandomInputGenerator implements InputGenerator
             {
                 case BYTE:
                     // TODO decide on string encoding for bytes and decode strings provided from file here
-                    final BEByteInputAttributeCategory inputCategory = input.getOrCreateByteCategory(category);
+                    final BEByteInputAttributeCategory byteInputCategory = input.getOrCreateByteCategory(category);
+                    byteInputCategory.setTrackingEnabled(this.inputTrackingEnabled);
                     throw new IllegalStateException("Byte data types are not yet supported");
                 case DOUBLE:
                     final BEDoubleInputAttributeCategory doubleInputCategory = input.getOrCreateDoubleCategory(category);
+                    doubleInputCategory.setTrackingEnabled(this.inputTrackingEnabled);
                     values.forEach(value -> doubleInputCategory.add(Double.valueOf(value)));
                     break;
                 case INT:
                     final BEIntInputAttributeCategory intInputCategory = input.getOrCreateIntCategory(category);
+                    intInputCategory.setTrackingEnabled(this.inputTrackingEnabled);
                     values.forEach(value -> intInputCategory.add(Integer.valueOf(value)));
                     break;
                 case LONG:
                     final BELongInputAttributeCategory longInputCategory = input.getOrCreateLongCategory(category);
-                    values.forEach(value -> longInputCategory.add(Integer.valueOf(value)));
+                    longInputCategory.setTrackingEnabled(this.inputTrackingEnabled);
+                    values.forEach(value -> longInputCategory.add(Long.valueOf(value)));
                     break;
                 case STRING:
                     final BEStringInputAttributeCategory stringInputCategory = input.getOrCreateStringCategory(category);
+                    stringInputCategory.setTrackingEnabled(this.inputTrackingEnabled);
                     values.forEach(stringInputCategory::add);
                     break;
                 default:

--- a/freebee-core/pom.xml
+++ b/freebee-core/pom.xml
@@ -65,5 +65,10 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/BEInterval.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/BEInterval.java
@@ -1,12 +1,13 @@
 package com.amobee.freebee.evaluator;
 
 import com.amobee.freebee.evaluator.interval.Interval;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
-import lombok.Data;
-
+import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.BitSet;
-import javax.annotation.Nonnull;
 
 /**
  * Expression interval representing a single conjunction node in a boolean expression. Expression intervals are stored
@@ -19,7 +20,9 @@ import javax.annotation.Nonnull;
  * @see com.amobee.freebee.evaluator.evaluator.BEEvaluatorBuilder
  * @see <a href="https://videologygroup.atlassian.net/wiki/pages/viewpage.action?pageId=24119554">Design: Boolean Expressions & Evaluator</a>
  */
-@Data
+@Getter
+@ToString
+@EqualsAndHashCode
 public class BEInterval implements Interval, Serializable
 {
     private static final long serialVersionUID = -2315253087374471503L;
@@ -29,8 +32,8 @@ public class BEInterval implements Interval, Serializable
     private final boolean canUseBitSetMatching;
     private final boolean negative;
     private final BitSet bits;
-    private short start;
-    private short end;
+    private final short start;
+    private final short end;
 
     public BEInterval(
             final int expressionId,

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/BEMatchedInterval.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/BEMatchedInterval.java
@@ -1,6 +1,7 @@
 package com.amobee.freebee.evaluator;
 
 import com.amobee.freebee.evaluator.evaluator.BEInputAttributeCategory;
+import com.amobee.freebee.evaluator.index.BEIndexExpressionResult;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -24,22 +25,32 @@ public class BEMatchedInterval extends BEInterval
     private static final long serialVersionUID = -2315253087374471504L;
 
     private BEInputAttributeCategory matchedInputValues;
+    private final boolean partialExpressionReferenceInterval;
+    private BEIndexExpressionResult partialExpressionIndexResult;
 
     public BEMatchedInterval(
             final int expressionId,
             final int intervalId,
+            final boolean isPartialExpressionReferenceInterval,
             final boolean canUseBitSetMatching,
             final boolean negative,
             @Nonnull final BitSet bits)
     {
         super(expressionId, intervalId, canUseBitSetMatching, negative, bits);
+        this.partialExpressionReferenceInterval = isPartialExpressionReferenceInterval;
     }
 
     public BEMatchedInterval(@Nonnull final BEInterval other)
     {
+        this(other, false);
+    }
+
+    public BEMatchedInterval(@Nonnull final BEInterval other, final boolean isPartialExpressionReferenceInterval)
+    {
         this(
                 other.getExpressionId(),
                 other.getIntervalId(),
+                isPartialExpressionReferenceInterval,
                 other.isCanUseBitSetMatching(),
                 other.isNegative(),
                 other.getBits()
@@ -70,6 +81,11 @@ public class BEMatchedInterval extends BEInterval
                 this.matchedInputValues.addAll(matchedInputAttributeCategoryValues);
             }
         }
+    }
+
+    public void setPartialExpressionIndexResult(final BEIndexExpressionResult partialExpressionIndexResult)
+    {
+        this.partialExpressionIndexResult = partialExpressionIndexResult;
     }
 
 };

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/BEMatchedInterval.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/BEMatchedInterval.java
@@ -1,0 +1,75 @@
+package com.amobee.freebee.evaluator;
+
+import com.amobee.freebee.evaluator.evaluator.BEInputAttributeCategory;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.BitSet;
+
+/**
+ * Expression interval capable of tracking the input values that resulted in matching an interval.
+ *
+ * Applications should never create instances of this class directly, it is used internally be a BEEvaluator.
+ *
+ * @author Kevin Doran
+ */
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = true)
+public class BEMatchedInterval extends BEInterval
+{
+    private static final long serialVersionUID = -2315253087374471504L;
+
+    private BEInputAttributeCategory matchedInputValues;
+
+    public BEMatchedInterval(
+            final int expressionId,
+            final int intervalId,
+            final boolean canUseBitSetMatching,
+            final boolean negative,
+            @Nonnull final BitSet bits)
+    {
+        super(expressionId, intervalId, canUseBitSetMatching, negative, bits);
+    }
+
+    public BEMatchedInterval(@Nonnull final BEInterval other)
+    {
+        this(
+                other.getExpressionId(),
+                other.getIntervalId(),
+                other.isCanUseBitSetMatching(),
+                other.isNegative(),
+                other.getBits()
+        );
+    }
+
+    public void addMatchedInputValues(@Nullable final BEInputAttributeCategory matchedInputAttributeCategoryValues)
+    {
+        if (matchedInputAttributeCategoryValues != null)
+        {
+            if (this.matchedInputValues == null)
+            {
+                this.matchedInputValues = matchedInputAttributeCategoryValues.clone();
+            } else
+            {
+                // Assert that incoming attribute category type / name matches the existing one for this interval
+                // and add incoming value(s) to the existing values for this interval.
+                if (!matchedInputAttributeCategoryValues.getClass().isAssignableFrom(this.matchedInputValues.getClass())
+                        || !matchedInputAttributeCategoryValues.getName().equals(this.matchedInputValues.getName()))
+                {
+                    throw new IllegalStateException(
+                            "Unexpected multiple attribute categories for a single expression interval. "
+                                    + "Was expecting " + this.matchedInputValues.getClass().getSimpleName()
+                                    + " named '" + this.matchedInputValues.getName() + "', but got"
+                                    + matchedInputAttributeCategoryValues.getClass().getSimpleName()
+                                    + " named '" + matchedInputAttributeCategoryValues.getName() + "'");
+                }
+                this.matchedInputValues.addAll(matchedInputAttributeCategoryValues);
+            }
+        }
+    }
+
+};

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEBaseInputAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEBaseInputAttributeCategory.java
@@ -1,7 +1,9 @@
 package com.amobee.freebee.evaluator.evaluator;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import javax.annotation.Nonnull;
-import java.util.Objects;
 
 /**
  * A base implementation class for BEInputAttributeCategory.
@@ -9,10 +11,12 @@ import java.util.Objects;
  * flor enabling tracking.
  * @author Kevin Doran
  */
+@ToString
+@EqualsAndHashCode
 public abstract class BEBaseInputAttributeCategory implements BEInputAttributeCategory
 {
-    private final String name;
-    private boolean trackingEnabled;
+    protected final String name;
+    protected boolean trackingEnabled;
 
     public BEBaseInputAttributeCategory(@Nonnull final String attributeCategoryName)
     {
@@ -44,27 +48,6 @@ public abstract class BEBaseInputAttributeCategory implements BEInputAttributeCa
     public void setTrackingEnabled(final boolean trackingEnabled)
     {
         this.trackingEnabled = trackingEnabled;
-    }
-
-    @Override
-    public boolean equals(final Object o)
-    {
-        if (this == o)
-        {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass())
-        {
-            return false;
-        }
-        final BEBaseInputAttributeCategory that = (BEBaseInputAttributeCategory) o;
-        return Objects.equals(this.name, that.name);
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash(this.name);
     }
 
     @Override

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEBaseInputAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEBaseInputAttributeCategory.java
@@ -1,0 +1,72 @@
+package com.amobee.freebee.evaluator.evaluator;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+/**
+ * A base implementation class for BEInputAttributeCategory.
+ * This class contains common fields such as attribute category name and a boolean flag
+ * flor enabling tracking.
+ * @author Kevin Doran
+ */
+public abstract class BEBaseInputAttributeCategory implements BEInputAttributeCategory
+{
+    private final String name;
+    private boolean trackingEnabled;
+
+    public BEBaseInputAttributeCategory(@Nonnull final String attributeCategoryName)
+    {
+        this(attributeCategoryName, false);
+    }
+
+    public BEBaseInputAttributeCategory(@Nonnull final String attributeCategoryName, final boolean trackingEnabled)
+    {
+        if (attributeCategoryName == null)
+        {
+            throw new IllegalArgumentException("attributeCategoryName must not be null");
+        }
+        this.name = attributeCategoryName;
+        this.trackingEnabled = trackingEnabled;
+    }
+
+    @Override
+    @Nonnull
+    public String getName()
+    {
+        return this.name;
+    }
+
+    public boolean isTrackingEnabled()
+    {
+        return this.trackingEnabled;
+    }
+
+    public void setTrackingEnabled(final boolean trackingEnabled)
+    {
+        this.trackingEnabled = trackingEnabled;
+    }
+
+    @Override
+    public boolean equals(final Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+        final BEBaseInputAttributeCategory that = (BEBaseInputAttributeCategory) o;
+        return Objects.equals(this.name, that.name);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(this.name);
+    }
+
+    @Override
+    public abstract BEInputAttributeCategory clone();
+}

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEBitSetEvaluator.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEBitSetEvaluator.java
@@ -35,6 +35,7 @@ import org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap;
 public class BEBitSetEvaluator<T> implements BEEvaluator<T>
 {
     private static final long serialVersionUID = 2180648924047679090L;
+    private static final String REF_INPUT_ATTRIBUTE_CATEGORY = "REFERENCE_EXPRESSIONS";
 
     private final BEIndex index;
     private final IntObjectMap<BEInfo<?>> partialExpressions;
@@ -69,7 +70,7 @@ public class BEBitSetEvaluator<T> implements BEEvaluator<T>
     @Nonnull
     public Set<T> evaluate(@Nonnull final BEInput input)
     {
-        final BEStringInputAttributeCategory refInputAttributeCategory = new BEStringInputAttributeCategory();
+        final BEStringInputAttributeCategory refInputAttributeCategory = new BEStringInputAttributeCategory(REF_INPUT_ATTRIBUTE_CATEGORY);
         final MutableIntObjectMap<BitSet> indexResult = new IntObjectHashMap<>(this.index.getIndexMetrics().getExpressionCount());
         final Set<T> evaluatorResult = new HashSet<>();
 
@@ -111,6 +112,15 @@ public class BEBitSetEvaluator<T> implements BEEvaluator<T>
         });
 
         return evaluatorResult;
+    }
+
+    @Nonnull
+    @Override
+    public BEEvaluatorResult<T> evaluateAndTrack(@Nonnull final BEInput input)
+    {
+        throw new UnsupportedOperationException(
+                "This feature is not implemented in by the deprecated BitSetEvaluator. " +
+                        "Please migrate to the BEHybridEvaluator.");
     }
 
     @Override

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEByteInputAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEByteInputAttributeCategory.java
@@ -4,20 +4,19 @@ import com.amobee.freebee.evaluator.BEInterval;
 import com.amobee.freebee.evaluator.index.BEAttributeCategoryMatchedIntervalConsumer;
 import com.amobee.freebee.evaluator.index.BEIndexAttributeCategory;
 import com.google.common.annotations.VisibleForTesting;
-import lombok.ToString;
+import lombok.EqualsAndHashCode;
 import org.eclipse.collections.api.list.primitive.ImmutableByteList;
 import org.eclipse.collections.api.list.primitive.MutableByteList;
 import org.eclipse.collections.impl.list.mutable.primitive.ByteArrayList;
 
 import javax.annotation.Nonnull;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
  * @author Michael Bond
  */
-@ToString
+@EqualsAndHashCode(callSuper = true)
 public class BEByteInputAttributeCategory extends BEBaseInputAttributeCategory
 {
     private final MutableByteList values = new ByteArrayList();
@@ -92,27 +91,12 @@ public class BEByteInputAttributeCategory extends BEBaseInputAttributeCategory
     }
 
     @Override
-    public boolean equals(final Object o)
+    public String toString()
     {
-        if (this == o)
-        {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass())
-        {
-            return false;
-        }
-        if (!super.equals(o))
-        {
-            return false;
-        }
-        final BEByteInputAttributeCategory that = (BEByteInputAttributeCategory) o;
-        return Objects.equals(this.values, that.values);
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash(super.hashCode(), this.values);
+        return "BEByteInputAttributeCategory{" +
+                "name='" + this.name + '\'' +
+                ", trackingEnabled=" + this.trackingEnabled +
+                ", values=" + this.values +
+                '}';
     }
 }

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEByteInputAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEByteInputAttributeCategory.java
@@ -1,29 +1,40 @@
 package com.amobee.freebee.evaluator.evaluator;
 
-import java.util.List;
-import java.util.function.Consumer;
-import javax.annotation.Nonnull;
-
 import com.amobee.freebee.evaluator.BEInterval;
+import com.amobee.freebee.evaluator.index.BEAttributeCategoryMatchedIntervalConsumer;
 import com.amobee.freebee.evaluator.index.BEIndexAttributeCategory;
 import com.google.common.annotations.VisibleForTesting;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.eclipse.collections.api.list.primitive.ImmutableByteList;
 import org.eclipse.collections.api.list.primitive.MutableByteList;
 import org.eclipse.collections.impl.list.mutable.primitive.ByteArrayList;
 
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
 /**
  * @author Michael Bond
  */
 @ToString
-@NoArgsConstructor
-public class BEByteInputAttributeCategory implements BEInputAttributeCategory
+public class BEByteInputAttributeCategory extends BEBaseInputAttributeCategory
 {
     private final MutableByteList values = new ByteArrayList();
 
+    public BEByteInputAttributeCategory(@Nonnull final String attributeCategoryName)
+    {
+        super(attributeCategoryName);
+    }
+
+    public BEByteInputAttributeCategory(@Nonnull final String attributeCategoryName, final boolean trackingEnabled)
+    {
+        super(attributeCategoryName, trackingEnabled);
+    }
+
     private BEByteInputAttributeCategory(@Nonnull final BEByteInputAttributeCategory category)
     {
+        super(category.getName(), category.isTrackingEnabled());
         this.values.addAll(category.values);
     }
 
@@ -41,14 +52,67 @@ public class BEByteInputAttributeCategory implements BEInputAttributeCategory
     }
 
     @Override
+    public void forEachMatchedInterval(
+            @Nonnull final BEIndexAttributeCategory indexAttributeCategory,
+            @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        this.values.forEach(value -> {
+            BEByteInputAttributeCategory matchedInput = null;
+            if (this.isTrackingEnabled())
+            {
+                matchedInput = new BEByteInputAttributeCategory(this.getName(), true);
+                matchedInput.add(value);
+            }
+            indexAttributeCategory.getIntervals(value, matchedInput, consumer);
+        });
+    }
+
+    @Override
     public BEByteInputAttributeCategory clone()
     {
         return new BEByteInputAttributeCategory(this);
+    }
+
+    @Override
+    public <C extends BEInputAttributeCategory> void addAll(final C other)
+    {
+        if (!(other instanceof BEByteInputAttributeCategory))
+        {
+            throw new IllegalArgumentException("Expected "
+                    + BEByteInputAttributeCategory.class.getSimpleName()
+                    + " but was passed " + other.getClass().getSimpleName());
+        }
+        this.values.addAll(((BEByteInputAttributeCategory) other).values);
     }
 
     @VisibleForTesting
     public ImmutableByteList getValues()
     {
         return this.values.toImmutable();
+    }
+
+    @Override
+    public boolean equals(final Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+        if (!super.equals(o))
+        {
+            return false;
+        }
+        final BEByteInputAttributeCategory that = (BEByteInputAttributeCategory) o;
+        return Objects.equals(this.values, that.values);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(super.hashCode(), this.values);
     }
 }

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BECompositeEvaluator.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BECompositeEvaluator.java
@@ -81,6 +81,14 @@ public class BECompositeEvaluator<T> implements BEEvaluator<T>
         return matchedResults;
     }
 
+    @Nonnull
+    @Override
+    public BEEvaluatorResult<T> evaluateAndTrack(@Nonnull final BEInput input)
+    {
+        throw new UnsupportedOperationException(
+                "This feature is not yet supported by the BECompositeEvaluator.");
+    }
+
     @Override
     public boolean equals(final Object o)
     {

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEDoubleInputAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEDoubleInputAttributeCategory.java
@@ -1,30 +1,40 @@
 package com.amobee.freebee.evaluator.evaluator;
 
-import java.util.List;
-import java.util.function.Consumer;
-import javax.annotation.Nonnull;
-
+import com.amobee.freebee.evaluator.BEInterval;
+import com.amobee.freebee.evaluator.index.BEAttributeCategoryMatchedIntervalConsumer;
+import com.amobee.freebee.evaluator.index.BEIndexAttributeCategory;
 import com.google.common.annotations.VisibleForTesting;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.eclipse.collections.api.list.primitive.ImmutableDoubleList;
 import org.eclipse.collections.api.list.primitive.MutableDoubleList;
 import org.eclipse.collections.impl.list.mutable.primitive.DoubleArrayList;
 
-import com.amobee.freebee.evaluator.BEInterval;
-import com.amobee.freebee.evaluator.index.BEIndexAttributeCategory;
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 /**
  * @author Michael Bond
  */
 @ToString
-@NoArgsConstructor
-public class BEDoubleInputAttributeCategory implements BEInputAttributeCategory
+public class BEDoubleInputAttributeCategory extends BEBaseInputAttributeCategory
 {
     private final MutableDoubleList values = new DoubleArrayList();
 
+    public BEDoubleInputAttributeCategory(@Nonnull final String attributeCategoryName)
+    {
+        super(attributeCategoryName);
+    }
+
+    public BEDoubleInputAttributeCategory(@Nonnull final String attributeCategoryName, final boolean trackingEnabled)
+    {
+        super(attributeCategoryName, trackingEnabled);
+    }
+
     private BEDoubleInputAttributeCategory(@Nonnull final BEDoubleInputAttributeCategory category)
     {
+        super(category.getName(), category.isTrackingEnabled());
         this.values.addAll(category.values);
     }
 
@@ -42,6 +52,34 @@ public class BEDoubleInputAttributeCategory implements BEInputAttributeCategory
     }
 
     @Override
+    public void forEachMatchedInterval(
+            @Nonnull final BEIndexAttributeCategory indexAttributeCategory,
+            @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        this.values.forEach(value -> {
+            BEDoubleInputAttributeCategory matchedInput = null;
+            if (this.isTrackingEnabled())
+            {
+                matchedInput = new BEDoubleInputAttributeCategory(this.getName(), true);
+                matchedInput.add(value);
+            }
+            indexAttributeCategory.getIntervals(value, matchedInput, consumer);
+        });
+    }
+
+    @Override
+    public <C extends BEInputAttributeCategory> void addAll(final C other)
+    {
+        if (!(other instanceof BEDoubleInputAttributeCategory))
+        {
+            throw new IllegalArgumentException("Expected "
+                    + BEDoubleInputAttributeCategory.class.getSimpleName()
+                    + " but was passed " + other.getClass().getSimpleName());
+        }
+        this.values.addAll(((BEDoubleInputAttributeCategory) other).values);
+    }
+
+    @Override
     public BEDoubleInputAttributeCategory clone()
     {
         return new BEDoubleInputAttributeCategory(this);
@@ -51,5 +89,30 @@ public class BEDoubleInputAttributeCategory implements BEInputAttributeCategory
     public ImmutableDoubleList getValues()
     {
         return this.values.toImmutable();
+    }
+
+    @Override
+    public boolean equals(final Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+        if (!super.equals(o))
+        {
+            return false;
+        }
+        final BEDoubleInputAttributeCategory that = (BEDoubleInputAttributeCategory) o;
+        return Objects.equals(this.values, that.values);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(super.hashCode(), this.values);
     }
 }

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEDoubleInputAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEDoubleInputAttributeCategory.java
@@ -4,20 +4,19 @@ import com.amobee.freebee.evaluator.BEInterval;
 import com.amobee.freebee.evaluator.index.BEAttributeCategoryMatchedIntervalConsumer;
 import com.amobee.freebee.evaluator.index.BEIndexAttributeCategory;
 import com.google.common.annotations.VisibleForTesting;
-import lombok.ToString;
+import lombok.EqualsAndHashCode;
 import org.eclipse.collections.api.list.primitive.ImmutableDoubleList;
 import org.eclipse.collections.api.list.primitive.MutableDoubleList;
 import org.eclipse.collections.impl.list.mutable.primitive.DoubleArrayList;
 
 import javax.annotation.Nonnull;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
  * @author Michael Bond
  */
-@ToString
+@EqualsAndHashCode(callSuper = true)
 public class BEDoubleInputAttributeCategory extends BEBaseInputAttributeCategory
 {
     private final MutableDoubleList values = new DoubleArrayList();
@@ -92,27 +91,12 @@ public class BEDoubleInputAttributeCategory extends BEBaseInputAttributeCategory
     }
 
     @Override
-    public boolean equals(final Object o)
+    public String toString()
     {
-        if (this == o)
-        {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass())
-        {
-            return false;
-        }
-        if (!super.equals(o))
-        {
-            return false;
-        }
-        final BEDoubleInputAttributeCategory that = (BEDoubleInputAttributeCategory) o;
-        return Objects.equals(this.values, that.values);
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash(super.hashCode(), this.values);
+        return "BEDoubleInputAttributeCategory{" +
+                "name='" + this.name + '\'' +
+                ", trackingEnabled=" + this.trackingEnabled +
+                ", values=" + this.values +
+                '}';
     }
 }

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEEvaluator.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEEvaluator.java
@@ -2,10 +2,10 @@ package com.amobee.freebee.evaluator.evaluator;
 
 import com.amobee.freebee.evaluator.index.BEIndexMetrics;
 
-import java.io.Serializable;
-import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.util.Set;
 
 /**
  * An interface for a free-form boolean expression evaluator.
@@ -26,6 +26,19 @@ public interface BEEvaluator<T> extends Serializable
      */
     @Nonnull
     Set<T> evaluate(@Nonnull BEInput input);
+
+    /**
+     * Evaluate expressions agains a given input, while tracking which input values
+     * are used to satisfy each expression.
+     *
+     * The result object stores both matched expressions and metadata about which
+     * input attribute values contributed to satisfying each matched expression.
+     *
+     * @return BEEvaluatorResult wrapper object for matched expressions that can
+     * be queried to lookup which input values contributed to the match
+     */
+    @Nonnull
+    BEEvaluatorResult<T> evaluateAndTrack(@Nonnull BEInput input);
 
     /**
      * Get summary metrics for the BEIndex that backs the evaluator.

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEEvaluatorResult.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEEvaluatorResult.java
@@ -1,0 +1,143 @@
+package com.amobee.freebee.evaluator.evaluator;
+
+import com.amobee.freebee.evaluator.BEMatchedInterval;
+import com.amobee.freebee.evaluator.index.BEIndexExpressionResult;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Represents the result of running a {@link BEEvaluator} against a given {@link BEInput}.
+ *
+ * Contains matched expressions and metadata about which input values contributed to
+ * satisfying each matched expressions.
+ *
+ * @param <T> The type of expression data for the given evaluator that generated this result object.
+ */
+public class BEEvaluatorResult<T>
+{
+
+    private final Set<T> matchedExpressionData = new HashSet<>();
+    private final Map<T, BEIndexExpressionResult> matchedExpressionIntervals = new HashMap<>();
+
+    public void add(final BEIndexExpressionResult matchedExpression, final T expressionData)
+    {
+        this.matchedExpressionData.add(expressionData);
+        this.matchedExpressionIntervals.put(expressionData, matchedExpression);
+    }
+
+    /**
+     * Returns the set of expression data for all matched expressions.
+     *
+     * @return a set of expression data (e.g., ID strings) corresponding to matched expressions for a given input.
+     */
+    public Set<T> getMatchedExpressions()
+    {
+        return this.matchedExpressionData;
+    }
+
+    /**
+     * Returns the possible combinations of input values that could satisfy a given expression.
+     *
+     * Input values are returned as 2D list, ie a list of lists.
+     * Each row in the outer list represents one possible way to satisfy the overall expression.
+     * Each inner list represents the input attribute category values required to fulfil the expression.
+     * For each attribute category entry in the inner list, one value must be used for the overall expression to be satisfied.
+     *
+     * Put another way: For the outer list, choose any row/entry. For the inner list for that selection,
+     * chose one value from every BEInputAttributeCategory in the list.
+     *
+     * Note: Input attribute categories and values are only returned if tracking is enabled when creating the input
+     * attribute category. Untracked categories will not appear at all in the return values of this method.
+     */
+    public List<List<? extends BEInputAttributeCategory>> getPossibleInputValuesThatSatisfy(final T expressionData)
+    {
+        if (expressionData == null)
+        {
+            return null;
+        }
+
+        final BEIndexExpressionResult indexExpressionResult = this.matchedExpressionIntervals.get(expressionData);
+
+        if (indexExpressionResult == null)
+        {
+            return null;
+        }
+
+        final List<List<BEMatchedInterval>> possibleCompleteIntervalPaths =
+                findAllPossibleIntervalPathsThatSatisfyTheExpression(indexExpressionResult);
+
+        final List<List<? extends BEInputAttributeCategory>> matchedInputValues = new ArrayList<>(possibleCompleteIntervalPaths.size());
+        for (final List<BEMatchedInterval> intervalPath : possibleCompleteIntervalPaths)
+        {
+            // Each path will result in a List<? extends BEInputAttributeCategory> where each element in
+            // the list is one set of possible values that would complete the leaf node in the expression
+            final List<? extends BEInputAttributeCategory> possibleValuesToSatisfyThisPath =
+                    intervalPath.stream()
+                            .map(BEMatchedInterval::getMatchedInputValues)
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toList());
+            if (!possibleValuesToSatisfyThisPath.isEmpty())
+            {
+                matchedInputValues.add(possibleValuesToSatisfyThisPath);
+            }
+        }
+
+        return matchedInputValues;
+    }
+
+    @Nonnull
+    private List<List<BEMatchedInterval>> findAllPossibleIntervalPathsThatSatisfyTheExpression(@Nonnull final BEIndexExpressionResult indexExpressionResult)
+    {
+        final Map<Integer, List<BEMatchedInterval>> intervalsByStartingPosition = new HashMap<>();
+        indexExpressionResult.getMatchedIntervals().forEach(interval -> {
+            final int start = interval.getStart();
+            intervalsByStartingPosition.putIfAbsent(start, new ArrayList<>());
+            intervalsByStartingPosition.get(start).add(interval);
+        });
+
+        final int currentPosition = 0;
+        final int terminalPosition = indexExpressionResult.getMaxIntervalLength() + 1;
+        final List<BEMatchedInterval> currentPath = new ArrayList<>();
+        final List<List<BEMatchedInterval>> completePaths = new ArrayList<>();
+
+        findAllCompleteIntervalPaths(currentPosition, terminalPosition, currentPath, intervalsByStartingPosition, completePaths);
+
+        return completePaths;
+    }
+
+    private void findAllCompleteIntervalPaths(
+            final int currentPosition,
+            final int terminalPosition,
+            final List<BEMatchedInterval> currentPath,
+            final Map<Integer, List<BEMatchedInterval>> intervalsByStartingPosition,
+            final List<List<BEMatchedInterval>> completePaths)
+    {
+        if (currentPosition + 1 == terminalPosition)
+        {
+            completePaths.add(new ArrayList<>(currentPath));
+            return;
+        }
+
+        // Recurse for all the intervals "touching" the end of the current interval
+        final List<BEMatchedInterval> intervalsStartingAtCurrentPosition = intervalsByStartingPosition.get(currentPosition);
+        if (intervalsStartingAtCurrentPosition != null)
+        {
+            for (final BEMatchedInterval interval : intervalsByStartingPosition.get(currentPosition))
+            {
+                currentPath.add(interval);
+                final int nextIntervalEndPosition = interval.getEnd();
+                findAllCompleteIntervalPaths(nextIntervalEndPosition, terminalPosition, currentPath, intervalsByStartingPosition, completePaths);
+                currentPath.remove(currentPath.size() - 1);
+            }
+        }
+    }
+
+}

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEHybridEvaluator.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEHybridEvaluator.java
@@ -1,18 +1,19 @@
 package com.amobee.freebee.evaluator.evaluator;
 
 import com.amobee.freebee.evaluator.BEInterval;
+import com.amobee.freebee.evaluator.BEMatchedInterval;
 import com.amobee.freebee.evaluator.index.BEIndex;
 import com.amobee.freebee.evaluator.index.BEIndexExpressionResult;
 import com.amobee.freebee.evaluator.index.BEIndexMetrics;
 import com.amobee.freebee.evaluator.index.BEIndexResults;
 import com.amobee.freebee.evaluator.interval.Interval;
 
+import javax.annotation.Nonnull;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import javax.annotation.Nonnull;
 
 /**
  * An implementation of {@link BEEvaluator} that uses a hybrid matching algorithm
@@ -58,7 +59,16 @@ public class BEHybridEvaluator<T> implements BEEvaluator<T>
     @Override
     public Set<T> evaluate(@Nonnull final BEInput input)
     {
-        final Set<T> evaluatorResult = new HashSet<>();
+        final BEEvaluatorResult<T> evaluatorResult = evaluateAndTrack(input);
+        return evaluatorResult.getMatchedExpressions();
+    }
+
+    @Nonnull
+    @Override
+    public BEEvaluatorResult evaluateAndTrack(@Nonnull final BEInput input)
+    {
+
+        final BEEvaluatorResult<T> evaluatorResult = new BEEvaluatorResult<>();
 
         final BEIndexResults expressionIntervals = queryIndexForMatchingExpressionIntervals(input);
 
@@ -70,7 +80,7 @@ public class BEHybridEvaluator<T> implements BEEvaluator<T>
             {
                 if (match(indexResult))
                 {
-                    evaluatorResult.add(expressionData);
+                    evaluatorResult.add(indexResult, expressionData);
                 }
             }
         });
@@ -114,7 +124,7 @@ public class BEHybridEvaluator<T> implements BEEvaluator<T>
     private boolean matchUsingIntervals(final BEIndexExpressionResult expressionIndexResult)
     {
         // get the intervals to match, **important** they must be sorted by start index
-        final List<BEInterval> intervals = expressionIndexResult.getMatchedIntervals();
+        final List<BEMatchedInterval> intervals = expressionIndexResult.getMatchedIntervals();
         intervals.sort(Comparator.comparingInt(Interval::getStart));
 
         // create a matched array that spans all intervals across the entire expression

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEHybridEvaluator.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEHybridEvaluator.java
@@ -10,10 +10,10 @@ import com.amobee.freebee.evaluator.interval.Interval;
 
 import javax.annotation.Nonnull;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * An implementation of {@link BEEvaluator} that uses a hybrid matching algorithm
@@ -94,17 +94,15 @@ public class BEHybridEvaluator<T> implements BEEvaluator<T>
         final BEIndexResults indexResults = this.index.findMatchingExpressionIntervals(input);
 
         // Using the matched expression intervals, evaluate partial expressions that were fully matched by the input
-        final Set<String> matchedPartialExpressionNames = new HashSet<>();
-        indexResults.getExpressionResults()
+        final List<BEIndexExpressionResult> matchedPartialExpressions = indexResults.getExpressionResults()
                 .stream()
                 .filter(BEIndexExpressionResult::isPartial)
                 .filter(this::match)
-                .map(BEIndexExpressionResult::getPartialExpressionName)
-                .forEach(matchedPartialExpressionNames::add);
+                .collect(Collectors.toList());
 
         // If any partial expressions were matched, we must now add the referenced partial expression ids to the input
         // and rerun the index query to find more intervals (for full expressions) that may now match.
-        this.index.addRefIntervalsForMatchedPartialExpressions(matchedPartialExpressionNames, indexResults);
+        this.index.addRefIntervalsForMatchedPartialExpressions(matchedPartialExpressions, indexResults);
         return indexResults;
     }
 

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEInput.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEInput.java
@@ -21,7 +21,7 @@ public class BEInput implements Cloneable
     private BEInput(@Nonnull final BEInput beInput)
     {
         this.attributeCategories
-            .putAll(beInput.attributeCategories.collectValues((key, category) -> category.clone()));
+                .putAll(beInput.attributeCategories.collectValues((key, category) -> category.clone()));
     }
 
     @Nullable
@@ -40,7 +40,7 @@ public class BEInput implements Cloneable
     @Nonnull
     public BEByteInputAttributeCategory getOrCreateByteCategory(@Nonnull final String attributeCategory)
     {
-        return (BEByteInputAttributeCategory) this.attributeCategories.getIfAbsentPut(
+        return (BEByteInputAttributeCategory) this.attributeCategories.getIfAbsentPutWithKey(
                 attributeCategory.toUpperCase(),
                 BEByteInputAttributeCategory::new);
     }
@@ -55,7 +55,7 @@ public class BEInput implements Cloneable
     @Nonnull
     public BEDoubleInputAttributeCategory getOrCreateDoubleCategory(@Nonnull final String attributeCategory)
     {
-        return (BEDoubleInputAttributeCategory) this.attributeCategories.getIfAbsentPut(
+        return (BEDoubleInputAttributeCategory) this.attributeCategories.getIfAbsentPutWithKey(
                 attributeCategory.toUpperCase(),
                 BEDoubleInputAttributeCategory::new);
     }
@@ -70,7 +70,7 @@ public class BEInput implements Cloneable
     @Nonnull
     public BEIntInputAttributeCategory getOrCreateIntCategory(@Nonnull final String attributeCategory)
     {
-        return (BEIntInputAttributeCategory) this.attributeCategories.getIfAbsentPut(
+        return (BEIntInputAttributeCategory) this.attributeCategories.getIfAbsentPutWithKey(
                 attributeCategory.toUpperCase(),
                 BEIntInputAttributeCategory::new);
     }
@@ -85,7 +85,7 @@ public class BEInput implements Cloneable
     @Nonnull
     public BELongInputAttributeCategory getOrCreateLongCategory(@Nonnull final String attributeCategory)
     {
-        return (BELongInputAttributeCategory) this.attributeCategories.getIfAbsentPut(
+        return (BELongInputAttributeCategory) this.attributeCategories.getIfAbsentPutWithKey(
                 attributeCategory.toUpperCase(),
                 BELongInputAttributeCategory::new);
     }
@@ -100,7 +100,7 @@ public class BEInput implements Cloneable
     @Nonnull
     public BEStringInputAttributeCategory getOrCreateStringCategory(@Nonnull final String attributeCategory)
     {
-        return (BEStringInputAttributeCategory) this.attributeCategories.getIfAbsentPut(
+        return (BEStringInputAttributeCategory) this.attributeCategories.getIfAbsentPutWithKey(
                 attributeCategory.toUpperCase(),
                 BEStringInputAttributeCategory::new);
     }

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEInputAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEInputAttributeCategory.java
@@ -1,29 +1,44 @@
 package com.amobee.freebee.evaluator.evaluator;
 
+import com.amobee.freebee.evaluator.BEInterval;
+import com.amobee.freebee.evaluator.index.BEAttributeCategoryMatchedIntervalConsumer;
+import com.amobee.freebee.evaluator.index.BEIndexAttributeCategory;
+
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
-
-import com.amobee.freebee.evaluator.BEInterval;
-import com.amobee.freebee.evaluator.index.BEIndexAttributeCategory;
 
 /**
  * @author Michael Bond
  */
 public interface BEInputAttributeCategory extends Cloneable
 {
+
+    /**
+     * Returns the name of the attribute category for these input values
+     *
+     * @return the attribute category name
+     */
+    String getName();
+
     /**
      * Iterates over all values in this input attribute category and invokes the consumer for each value that has
      * intervals in the specified index.
      *
-     * @param indexAttributeCategory
-     *         Index to find intervals matching the input values.
-     * @param consumer
-     *         Consumer to call with matching intervals.
+     * @param indexAttributeCategory Index to find intervals matching the input values.
+     * @param consumer               Consumer to call with matching intervals.
+     * @deprecated Use {@link #forEachMatchedInterval(BEIndexAttributeCategory, BEAttributeCategoryMatchedIntervalConsumer)}.
      */
+    @Deprecated
     void forEachMatchedInterval(
             @Nonnull BEIndexAttributeCategory indexAttributeCategory,
             @Nonnull Consumer<List<BEInterval>> consumer);
+
+    void forEachMatchedInterval(
+            @Nonnull BEIndexAttributeCategory indexAttributeCategory,
+            @Nonnull BEAttributeCategoryMatchedIntervalConsumer consumer);
+
+    <C extends BEInputAttributeCategory> void addAll(C other);
 
     BEInputAttributeCategory clone();
 }

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEIntInputAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEIntInputAttributeCategory.java
@@ -1,30 +1,40 @@
 package com.amobee.freebee.evaluator.evaluator;
 
-import java.util.List;
-import java.util.function.Consumer;
-import javax.annotation.Nonnull;
-
+import com.amobee.freebee.evaluator.BEInterval;
+import com.amobee.freebee.evaluator.index.BEAttributeCategoryMatchedIntervalConsumer;
+import com.amobee.freebee.evaluator.index.BEIndexAttributeCategory;
 import com.google.common.annotations.VisibleForTesting;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.eclipse.collections.api.list.primitive.ImmutableIntList;
 import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
 
-import com.amobee.freebee.evaluator.BEInterval;
-import com.amobee.freebee.evaluator.index.BEIndexAttributeCategory;
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 /**
  * @author Michael Bond
  */
 @ToString
-@NoArgsConstructor
-public class BEIntInputAttributeCategory implements BEInputAttributeCategory
+public class BEIntInputAttributeCategory extends BEBaseInputAttributeCategory
 {
     private final MutableIntList values = new IntArrayList();
 
+    public BEIntInputAttributeCategory(@Nonnull final String attributeCategoryName)
+    {
+        super(attributeCategoryName);
+    }
+
+    public BEIntInputAttributeCategory(@Nonnull final String attributeCategoryName, final boolean trackingEnabled)
+    {
+        super(attributeCategoryName, trackingEnabled);
+    }
+
     private BEIntInputAttributeCategory(@Nonnull final BEIntInputAttributeCategory category)
     {
+        super(category.getName(), category.isTrackingEnabled());
         this.values.addAll(category.values);
     }
 
@@ -42,6 +52,34 @@ public class BEIntInputAttributeCategory implements BEInputAttributeCategory
     }
 
     @Override
+    public void forEachMatchedInterval(
+            @Nonnull final BEIndexAttributeCategory indexAttributeCategory,
+            @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        this.values.forEach(value -> {
+            BEIntInputAttributeCategory matchedInput = null;
+            if (this.isTrackingEnabled())
+            {
+                matchedInput = new BEIntInputAttributeCategory(this.getName(), true);
+                matchedInput.add(value);
+            }
+            indexAttributeCategory.getIntervals(value, matchedInput, consumer);
+        });
+    }
+
+    @Override
+    public <C extends BEInputAttributeCategory> void addAll(final C other)
+    {
+        if (!(other instanceof BEIntInputAttributeCategory))
+        {
+            throw new IllegalArgumentException("Expected "
+                    + BEIntInputAttributeCategory.class.getSimpleName()
+                    + " but was passed " + other.getClass().getSimpleName());
+        }
+        this.values.addAll(((BEIntInputAttributeCategory) other).values);
+    }
+
+    @Override
     public BEIntInputAttributeCategory clone()
     {
         return new BEIntInputAttributeCategory(this);
@@ -51,5 +89,30 @@ public class BEIntInputAttributeCategory implements BEInputAttributeCategory
     public ImmutableIntList getValues()
     {
         return this.values.toImmutable();
+    }
+
+    @Override
+    public boolean equals(final Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+        if (!super.equals(o))
+        {
+            return false;
+        }
+        final BEIntInputAttributeCategory that = (BEIntInputAttributeCategory) o;
+        return Objects.equals(this.values, that.values);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(super.hashCode(), this.values);
     }
 }

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEIntInputAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEIntInputAttributeCategory.java
@@ -4,20 +4,19 @@ import com.amobee.freebee.evaluator.BEInterval;
 import com.amobee.freebee.evaluator.index.BEAttributeCategoryMatchedIntervalConsumer;
 import com.amobee.freebee.evaluator.index.BEIndexAttributeCategory;
 import com.google.common.annotations.VisibleForTesting;
-import lombok.ToString;
+import lombok.EqualsAndHashCode;
 import org.eclipse.collections.api.list.primitive.ImmutableIntList;
 import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
 
 import javax.annotation.Nonnull;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
  * @author Michael Bond
  */
-@ToString
+@EqualsAndHashCode(callSuper = true)
 public class BEIntInputAttributeCategory extends BEBaseInputAttributeCategory
 {
     private final MutableIntList values = new IntArrayList();
@@ -92,27 +91,12 @@ public class BEIntInputAttributeCategory extends BEBaseInputAttributeCategory
     }
 
     @Override
-    public boolean equals(final Object o)
+    public String toString()
     {
-        if (this == o)
-        {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass())
-        {
-            return false;
-        }
-        if (!super.equals(o))
-        {
-            return false;
-        }
-        final BEIntInputAttributeCategory that = (BEIntInputAttributeCategory) o;
-        return Objects.equals(this.values, that.values);
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash(super.hashCode(), this.values);
+        return "BEIntInputAttributeCategory{" +
+                "name='" + this.name + '\'' +
+                ", trackingEnabled=" + this.trackingEnabled +
+                ", values=" + this.values +
+                '}';
     }
 }

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BELongInputAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BELongInputAttributeCategory.java
@@ -1,30 +1,40 @@
 package com.amobee.freebee.evaluator.evaluator;
 
-import java.util.List;
-import java.util.function.Consumer;
-import javax.annotation.Nonnull;
-
+import com.amobee.freebee.evaluator.BEInterval;
+import com.amobee.freebee.evaluator.index.BEAttributeCategoryMatchedIntervalConsumer;
+import com.amobee.freebee.evaluator.index.BEIndexAttributeCategory;
 import com.google.common.annotations.VisibleForTesting;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.eclipse.collections.api.list.primitive.ImmutableLongList;
 import org.eclipse.collections.api.list.primitive.MutableLongList;
 import org.eclipse.collections.impl.list.mutable.primitive.LongArrayList;
 
-import com.amobee.freebee.evaluator.BEInterval;
-import com.amobee.freebee.evaluator.index.BEIndexAttributeCategory;
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 /**
  * @author Michael Bond
  */
 @ToString
-@NoArgsConstructor
-public class BELongInputAttributeCategory implements BEInputAttributeCategory
+public class BELongInputAttributeCategory extends BEBaseInputAttributeCategory
 {
     private final MutableLongList values = new LongArrayList();
 
+    public BELongInputAttributeCategory(@Nonnull final String attributeCategoryName)
+    {
+        super(attributeCategoryName);
+    }
+
+    public BELongInputAttributeCategory(@Nonnull final String attributeCategoryName, final boolean trackingEnabled)
+    {
+        super(attributeCategoryName, trackingEnabled);
+    }
+
     private BELongInputAttributeCategory(@Nonnull final BELongInputAttributeCategory category)
     {
+        super(category.getName(), category.isTrackingEnabled());
         this.values.addAll(category.values);
     }
 
@@ -42,6 +52,34 @@ public class BELongInputAttributeCategory implements BEInputAttributeCategory
     }
 
     @Override
+    public void forEachMatchedInterval(
+            @Nonnull final BEIndexAttributeCategory indexAttributeCategory,
+            @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        this.values.forEach(value -> {
+            BELongInputAttributeCategory matchedInput = null;
+            if (this.isTrackingEnabled())
+            {
+                matchedInput = new BELongInputAttributeCategory(this.getName(), true);
+                matchedInput.add(value);
+            }
+            indexAttributeCategory.getIntervals(value, matchedInput, consumer);
+        });
+    }
+
+    @Override
+    public <C extends BEInputAttributeCategory> void addAll(final C other)
+    {
+        if (!(other instanceof BELongInputAttributeCategory))
+        {
+            throw new IllegalArgumentException("Expected "
+                    + BELongInputAttributeCategory.class.getSimpleName()
+                    + " but was passed " + other.getClass().getSimpleName());
+        }
+        this.values.addAll(((BELongInputAttributeCategory) other).values);
+    }
+
+    @Override
     public BELongInputAttributeCategory clone()
     {
         return new BELongInputAttributeCategory(this);
@@ -51,5 +89,30 @@ public class BELongInputAttributeCategory implements BEInputAttributeCategory
     public ImmutableLongList getValues()
     {
         return this.values.toImmutable();
+    }
+
+    @Override
+    public boolean equals(final Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+        if (!super.equals(o))
+        {
+            return false;
+        }
+        final BELongInputAttributeCategory that = (BELongInputAttributeCategory) o;
+        return Objects.equals(this.values, that.values);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(super.hashCode(), this.values);
     }
 }

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BELongInputAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BELongInputAttributeCategory.java
@@ -4,20 +4,19 @@ import com.amobee.freebee.evaluator.BEInterval;
 import com.amobee.freebee.evaluator.index.BEAttributeCategoryMatchedIntervalConsumer;
 import com.amobee.freebee.evaluator.index.BEIndexAttributeCategory;
 import com.google.common.annotations.VisibleForTesting;
-import lombok.ToString;
+import lombok.EqualsAndHashCode;
 import org.eclipse.collections.api.list.primitive.ImmutableLongList;
 import org.eclipse.collections.api.list.primitive.MutableLongList;
 import org.eclipse.collections.impl.list.mutable.primitive.LongArrayList;
 
 import javax.annotation.Nonnull;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
  * @author Michael Bond
  */
-@ToString
+@EqualsAndHashCode(callSuper = true)
 public class BELongInputAttributeCategory extends BEBaseInputAttributeCategory
 {
     private final MutableLongList values = new LongArrayList();
@@ -92,27 +91,12 @@ public class BELongInputAttributeCategory extends BEBaseInputAttributeCategory
     }
 
     @Override
-    public boolean equals(final Object o)
+    public String toString()
     {
-        if (this == o)
-        {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass())
-        {
-            return false;
-        }
-        if (!super.equals(o))
-        {
-            return false;
-        }
-        final BELongInputAttributeCategory that = (BELongInputAttributeCategory) o;
-        return Objects.equals(this.values, that.values);
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash(super.hashCode(), this.values);
+        return "BELongInputAttributeCategory{" +
+                "name='" + this.name + '\'' +
+                ", trackingEnabled=" + this.trackingEnabled +
+                ", values=" + this.values +
+                '}';
     }
 }

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEStringInputAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEStringInputAttributeCategory.java
@@ -5,18 +5,17 @@ import com.amobee.freebee.evaluator.index.BEAttributeCategoryMatchedIntervalCons
 import com.amobee.freebee.evaluator.index.BEIndexAttributeCategory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import lombok.ToString;
+import lombok.EqualsAndHashCode;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
  * @author Michael Bond
  */
-@ToString
+@EqualsAndHashCode(callSuper = true)
 public class BEStringInputAttributeCategory extends BEBaseInputAttributeCategory
 {
     private final List<String> values = new ArrayList<>();
@@ -84,34 +83,19 @@ public class BEStringInputAttributeCategory extends BEBaseInputAttributeCategory
         return new BEStringInputAttributeCategory(this);
     }
 
-    @Override
-    public boolean equals(final Object o)
-    {
-        if (this == o)
-        {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass())
-        {
-            return false;
-        }
-        if (!super.equals(o))
-        {
-            return false;
-        }
-        final BEStringInputAttributeCategory that = (BEStringInputAttributeCategory) o;
-        return Objects.equals(this.values, that.values);
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash(super.hashCode(), this.values);
-    }
-
     @VisibleForTesting
     public ImmutableList<String> getValues()
     {
         return ImmutableList.copyOf(this.values);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "BEStringInputAttributeCategory{" +
+                "name='" + this.name + '\'' +
+                ", trackingEnabled=" + this.trackingEnabled +
+                ", values=" + this.values +
+                '}';
     }
 }

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEStringInputAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/evaluator/BEStringInputAttributeCategory.java
@@ -1,29 +1,39 @@
 package com.amobee.freebee.evaluator.evaluator;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
-import javax.annotation.Nonnull;
-
+import com.amobee.freebee.evaluator.BEInterval;
+import com.amobee.freebee.evaluator.index.BEAttributeCategoryMatchedIntervalConsumer;
+import com.amobee.freebee.evaluator.index.BEIndexAttributeCategory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-import com.amobee.freebee.evaluator.BEInterval;
-import com.amobee.freebee.evaluator.index.BEIndexAttributeCategory;
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 /**
  * @author Michael Bond
  */
 @ToString
-@NoArgsConstructor
-public class BEStringInputAttributeCategory implements BEInputAttributeCategory
+public class BEStringInputAttributeCategory extends BEBaseInputAttributeCategory
 {
     private final List<String> values = new ArrayList<>();
 
+    public BEStringInputAttributeCategory(@Nonnull final String attributeCategoryName)
+    {
+        super(attributeCategoryName);
+    }
+
+    public BEStringInputAttributeCategory(@Nonnull final String attributeCategoryName, final boolean trackingEnabled)
+    {
+        super(attributeCategoryName, trackingEnabled);
+    }
+
     private BEStringInputAttributeCategory(@Nonnull final BEStringInputAttributeCategory category)
     {
+        super(category.getName(), category.isTrackingEnabled());
         this.values.addAll(category.values);
     }
 
@@ -41,9 +51,62 @@ public class BEStringInputAttributeCategory implements BEInputAttributeCategory
     }
 
     @Override
+    public void forEachMatchedInterval(
+            @Nonnull final BEIndexAttributeCategory indexAttributeCategory,
+            @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        this.values.forEach(value -> {
+            BEStringInputAttributeCategory matchedInput = null;
+            if (this.isTrackingEnabled())
+            {
+                matchedInput = new BEStringInputAttributeCategory(this.getName(), true);
+                matchedInput.add(value);
+            }
+            indexAttributeCategory.getIntervals(value, matchedInput, consumer);
+        });
+    }
+
+    @Override
+    public <C extends BEInputAttributeCategory> void addAll(final C other)
+    {
+        if (!(other instanceof BEStringInputAttributeCategory))
+        {
+            throw new IllegalArgumentException("Expected "
+                    + BEStringInputAttributeCategory.class.getSimpleName()
+                    + " but was passed " + other.getClass().getSimpleName());
+        }
+        this.values.addAll(((BEStringInputAttributeCategory) other).values);
+    }
+
+    @Override
     public BEStringInputAttributeCategory clone()
     {
         return new BEStringInputAttributeCategory(this);
+    }
+
+    @Override
+    public boolean equals(final Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+        if (!super.equals(o))
+        {
+            return false;
+        }
+        final BEStringInputAttributeCategory that = (BEStringInputAttributeCategory) o;
+        return Objects.equals(this.values, that.values);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(super.hashCode(), this.values);
     }
 
     @VisibleForTesting

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEAbstractRangeIndexAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEAbstractRangeIndexAttributeCategory.java
@@ -1,16 +1,17 @@
 package com.amobee.freebee.evaluator.index;
 
 import com.amobee.freebee.evaluator.BEInterval;
+import com.amobee.freebee.evaluator.evaluator.BEInputAttributeCategory;
 import com.amobee.freebee.util.RangeUtils;
+import com.google.common.collect.Range;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
-
-import com.google.common.collect.Range;
 
 /**
  * @author Michael Bond
@@ -48,7 +49,12 @@ public abstract class BEAbstractRangeIndexAttributeCategory<T extends Comparable
     public void getIntervals(final byte attributeValue, @Nonnull final Consumer<List<BEInterval>> consumer)
     {
         callConsumer((List<BEInterval>) this.rangeIndex.get(valueOf(attributeValue)), consumer);
+    }
 
+    @Override
+    public void getIntervals(final byte attributeValue, @Nullable final BEInputAttributeCategory matchedInput, @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        callConsumer((List<BEInterval>) this.rangeIndex.get(valueOf(attributeValue)), matchedInput, consumer);
     }
 
     @Override
@@ -58,9 +64,21 @@ public abstract class BEAbstractRangeIndexAttributeCategory<T extends Comparable
     }
 
     @Override
+    public void getIntervals(final double attributeValue, @Nullable final BEInputAttributeCategory matchedInput, @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        callConsumer((List<BEInterval>) this.rangeIndex.get(valueOf(attributeValue)), matchedInput, consumer);
+    }
+
+    @Override
     public void getIntervals(final int attributeValue, @Nonnull final Consumer<List<BEInterval>> consumer)
     {
         callConsumer((List<BEInterval>) this.rangeIndex.get(valueOf(attributeValue)), consumer);
+    }
+
+    @Override
+    public void getIntervals(final int attributeValue, @Nullable final BEInputAttributeCategory matchedInput, @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        callConsumer((List<BEInterval>) this.rangeIndex.get(valueOf(attributeValue)), matchedInput, consumer);
     }
 
     @Override
@@ -70,10 +88,26 @@ public abstract class BEAbstractRangeIndexAttributeCategory<T extends Comparable
     }
 
     @Override
+    public void getIntervals(final long attributeValue, @Nullable final BEInputAttributeCategory matchedInput, @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        callConsumer((List<BEInterval>) this.rangeIndex.get(valueOf(attributeValue)), matchedInput, consumer);
+    }
+
+    @Override
     public void getIntervals(@Nonnull final String attributeValue, @Nonnull final Consumer<List<BEInterval>> consumer)
     {
         final Range<T> range = RangeUtils.createRange(attributeValue, this::valueOf);
         callConsumer((List<BEInterval>) this.rangeIndex.get(range), consumer);
+    }
+
+    @Override
+    public void getIntervals(
+            @Nonnull final String attributeValue,
+            @Nullable final BEInputAttributeCategory matchedInput,
+            @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        final Range<T> range = RangeUtils.createRange(attributeValue, this::valueOf);
+        callConsumer((List<BEInterval>) this.rangeIndex.get(range), matchedInput, consumer);
     }
 
     protected T valueOf(final byte value)

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEAbstractStringIndexAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEAbstractStringIndexAttributeCategory.java
@@ -1,10 +1,12 @@
 package com.amobee.freebee.evaluator.index;
 
+import com.amobee.freebee.evaluator.BEInterval;
+import com.amobee.freebee.evaluator.evaluator.BEInputAttributeCategory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
-
-import com.amobee.freebee.evaluator.BEInterval;
 
 /**
  * @author Michael Bond
@@ -25,9 +27,25 @@ public abstract class BEAbstractStringIndexAttributeCategory extends BEIndexAttr
     }
 
     @Override
+    public void getIntervals(final byte attributeValue,
+                             @Nullable final BEInputAttributeCategory matchedInput,
+                             @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        getIntervals(String.valueOf(attributeValue), matchedInput, consumer);
+    }
+
+    @Override
     public void getIntervals(final double attributeValue, @Nonnull final Consumer<List<BEInterval>> consumer)
     {
         getIntervals(String.valueOf(attributeValue), consumer);
+    }
+
+    @Override
+    public void getIntervals(final double attributeValue,
+                             @Nullable final BEInputAttributeCategory matchedInput,
+                             @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        getIntervals(String.valueOf(attributeValue), matchedInput, consumer);
     }
 
     @Override
@@ -37,9 +55,25 @@ public abstract class BEAbstractStringIndexAttributeCategory extends BEIndexAttr
     }
 
     @Override
+    public void getIntervals(final int attributeValue,
+                             @Nullable final BEInputAttributeCategory matchedInput,
+                             @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        getIntervals(String.valueOf(attributeValue), matchedInput, consumer);
+    }
+
+    @Override
     public void getIntervals(final long attributeValue, @Nonnull final Consumer<List<BEInterval>> consumer)
     {
         getIntervals(String.valueOf(attributeValue), consumer);
+    }
+
+    @Override
+    public void getIntervals(final long attributeValue,
+                             @Nullable final BEInputAttributeCategory matchedInput,
+                             @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        getIntervals(String.valueOf(attributeValue), matchedInput, consumer);
     }
 
     protected String getValue(@Nonnull final String value)

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEAttributeCategoryMatchedIntervalConsumer.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEAttributeCategoryMatchedIntervalConsumer.java
@@ -1,0 +1,24 @@
+package com.amobee.freebee.evaluator.index;
+
+import com.amobee.freebee.evaluator.BEInterval;
+import com.amobee.freebee.evaluator.evaluator.BEInputAttributeCategory;
+
+import java.util.List;
+
+/**
+ * An internal interface called during matching an input against indexed results.
+ */
+@FunctionalInterface
+public interface BEAttributeCategoryMatchedIntervalConsumer
+{
+
+    /**
+     * Interface to call when a match between an input and index is detected.
+     *
+     * @param inputAttributeCategory The input attribute category value(s) that resulted in the match.
+     *                               Can be null if input tracking is disabled.
+     * @param matchedIntervals The matched intervals in the index for the given input vlaue(s).
+     */
+    void accept(BEInputAttributeCategory inputAttributeCategory, List<BEInterval> matchedIntervals);
+
+}

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEByteIndexAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEByteIndexAttributeCategory.java
@@ -2,12 +2,14 @@ package com.amobee.freebee.evaluator.index;
 
 import com.amobee.freebee.config.BEDataTypeConfig;
 import com.amobee.freebee.evaluator.BEInterval;
+import com.amobee.freebee.evaluator.evaluator.BEInputAttributeCategory;
 import lombok.Getter;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.eclipse.collections.api.map.primitive.MutableByteObjectMap;
 import org.eclipse.collections.impl.factory.primitive.ByteObjectMaps;
@@ -48,9 +50,26 @@ public class BEByteIndexAttributeCategory extends BEIndexAttributeCategory imple
     }
 
     @Override
+    public void getIntervals(final byte attributeValue,
+                             @Nullable final BEInputAttributeCategory matchedInput,
+                             @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        callConsumer(this.values.get(attributeValue), matchedInput, consumer);
+    }
+
+    @Override
     public void getIntervals(@Nonnull final String attributeValue, @Nonnull final Consumer<List<BEInterval>> consumer)
     {
         callConsumer(this.values.get(Byte.parseByte(attributeValue)), consumer);
+    }
+
+    @Override
+    public void getIntervals(
+            @Nonnull final String attributeValue,
+            @Nullable final BEInputAttributeCategory matchedInput,
+            @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        callConsumer(this.values.get(Byte.parseByte(attributeValue)), matchedInput, consumer);
     }
 
     @Override

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEDoubleIndexAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEDoubleIndexAttributeCategory.java
@@ -1,11 +1,13 @@
 package com.amobee.freebee.evaluator.index;
 
+import com.amobee.freebee.evaluator.evaluator.BEInputAttributeCategory;
 import lombok.Getter;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.eclipse.collections.api.map.primitive.MutableDoubleObjectMap;
 import org.eclipse.collections.impl.factory.primitive.DoubleObjectMaps;
@@ -51,9 +53,33 @@ public class BEDoubleIndexAttributeCategory extends BEIndexAttributeCategory imp
     }
 
     @Override
+    public void getIntervals(final byte attributeValue, @Nullable final BEInputAttributeCategory matchedInput, @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        callConsumer(this.values.get(attributeValue), matchedInput, consumer);
+    }
+
+    @Override
+    public void getIntervals(final double attributeValue, @Nonnull final Consumer<List<BEInterval>> consumer)
+    {
+        callConsumer(this.values.get(attributeValue), consumer);
+    }
+
+    @Override
+    public void getIntervals(final double attributeValue, @Nullable final BEInputAttributeCategory matchedInput, @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        callConsumer(this.values.get(attributeValue), matchedInput, consumer);
+    }
+
+    @Override
     public void getIntervals(final int attributeValue, @Nonnull final Consumer<List<BEInterval>> consumer)
     {
         callConsumer(this.values.get(attributeValue), consumer);
+    }
+
+    @Override
+    public void getIntervals(final int attributeValue, @Nullable final BEInputAttributeCategory matchedInput, @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        callConsumer(this.values.get(attributeValue), matchedInput, consumer);
     }
 
     @Override
@@ -63,9 +89,24 @@ public class BEDoubleIndexAttributeCategory extends BEIndexAttributeCategory imp
     }
 
     @Override
+    public void getIntervals(final long attributeValue, @Nullable final BEInputAttributeCategory matchedInput, @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        callConsumer(this.values.get(attributeValue), matchedInput, consumer);
+    }
+
+    @Override
     public void getIntervals(@Nonnull final String attributeValue, @Nonnull final Consumer<List<BEInterval>> consumer)
     {
-        callConsumer(this.values.get(Long.parseLong(attributeValue)), consumer);
+        callConsumer(this.values.get(Double.parseDouble(attributeValue)), consumer);
+    }
+
+    @Override
+    public void getIntervals(
+            @Nonnull final String attributeValue,
+            @Nullable final BEInputAttributeCategory matchedInput,
+            @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        callConsumer(this.values.get(Double.parseDouble(attributeValue)), matchedInput, consumer);
     }
 
     @Override

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEIndex.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEIndex.java
@@ -1,18 +1,11 @@
 package com.amobee.freebee.evaluator.index;
 
+import com.amobee.freebee.config.BEDataTypeConfig;
+import com.amobee.freebee.evaluator.BEInterval;
 import com.amobee.freebee.evaluator.evaluator.BEInput;
 import com.amobee.freebee.evaluator.evaluator.BEInputAttributeCategory;
 import com.amobee.freebee.evaluator.evaluator.BEStringInputAttributeCategory;
-import com.amobee.freebee.config.BEDataTypeConfig;
-import com.amobee.freebee.evaluator.BEInterval;
 import com.amobee.freebee.expression.BEConstants;
-
-import java.io.Serializable;
-import java.util.BitSet;
-import java.util.Set;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.primitive.IntObjectMap;
 import org.eclipse.collections.api.map.primitive.MutableIntObjectMap;
@@ -20,6 +13,12 @@ import org.eclipse.collections.api.set.primitive.MutableIntSet;
 import org.eclipse.collections.impl.factory.Maps;
 import org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap;
 import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.util.BitSet;
+import java.util.Set;
 
 /**
  * Expression index runtime.
@@ -39,6 +38,7 @@ import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
 public class BEIndex<T> implements Serializable
 {
     private static final long serialVersionUID = -1533843770427265550L;
+    private static final String REF_INPUT_ATTRIBUTE_CATEGORY = "REFERENCE_EXPRESSIONS";
 
     private BEExpressionMetadataProvider expressionMetadataProvider;
     private BEExpressionDataProvider<T> expressionDataProvider;
@@ -254,7 +254,7 @@ public class BEIndex<T> implements Serializable
             @Nonnull final Set<String> matchedPartialExpressionNames,
             @Nonnull final BEIndexResults indexResults)
     {
-        final BEStringInputAttributeCategory refInputAttributeCategory = new BEStringInputAttributeCategory();
+        final BEStringInputAttributeCategory refInputAttributeCategory = new BEStringInputAttributeCategory(REF_INPUT_ATTRIBUTE_CATEGORY);
         matchedPartialExpressionNames.forEach(refInputAttributeCategory::add);
         evaluateAttributeCategory(refInputAttributeCategory, this.refAttributeCategory, indexResults);
     }
@@ -276,9 +276,9 @@ public class BEIndex<T> implements Serializable
         if (null != inputAttributeCategory)
         {
             // add intervals that match values of this attribute category in the input
-            inputAttributeCategory.forEachMatchedInterval(indexAttributeCategory, intervals ->
+            inputAttributeCategory.forEachMatchedInterval(indexAttributeCategory, (matchedInputValue, matchedIntervals) ->
             {
-                for (final BEInterval interval : intervals)
+                for (final BEInterval interval : matchedIntervals)
                 {
                     if (interval.isNegative())
                     {
@@ -287,7 +287,7 @@ public class BEIndex<T> implements Serializable
                     }
                     else
                     {
-                        indexResults.addInterval(interval);
+                        indexResults.addInterval(interval, matchedInputValue);
                     }
                 }
             });

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEIndexAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEIndexAttributeCategory.java
@@ -1,6 +1,7 @@
 package com.amobee.freebee.evaluator.index;
 
 import com.amobee.freebee.evaluator.BEInterval;
+import com.amobee.freebee.evaluator.evaluator.BEInputAttributeCategory;
 import lombok.Getter;
 
 import java.io.Serializable;
@@ -54,10 +55,40 @@ public abstract class BEIndexAttributeCategory implements Serializable
      *
      * @param attributeValue
      *         Attribute value to get intervals for.
+     * @param matchedInput
+     *         If tracking is enabled, contains the attribute category and value metadata to use for tracking matched inputs.
+     * @param consumer
+     *         Consumer to call with matched intervals.
+     */
+    public void getIntervals(final byte attributeValue, @Nullable final BEInputAttributeCategory matchedInput, @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        throw new UnsupportedOperationException("Cowardly refusal to risk loosing precision");
+    }
+
+    /**
+     * Get intervals matching the specified attribute value.
+     *
+     * @param attributeValue
+     *         Attribute value to get intervals for.
      * @param consumer
      *         Consumer to call with matched intervals.
      */
     public void getIntervals(final double attributeValue, @Nonnull final Consumer<List<BEInterval>> consumer)
+    {
+        throw new UnsupportedOperationException("Cowardly refusal to risk loosing precision");
+    }
+
+    /**
+     * Get intervals matching the specified attribute value.
+     *
+     * @param attributeValue
+     *         Attribute value to get intervals for.
+     * @param matchedInput
+     *         If tracking is enabled, contains the attribute category and value metadata to use for tracking matched inputs.
+     * @param consumer
+     *         Consumer to call with matched intervals.
+     */
+    public void getIntervals(final double attributeValue, @Nullable final BEInputAttributeCategory matchedInput, @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
     {
         throw new UnsupportedOperationException("Cowardly refusal to risk loosing precision");
     }
@@ -80,6 +111,21 @@ public abstract class BEIndexAttributeCategory implements Serializable
      *
      * @param attributeValue
      *         Attribute value to get intervals for.
+     * @param matchedInput
+     *         If tracking is enabled, contains the attribute category and value metadata to use for tracking matched inputs.
+     * @param consumer
+     *         Consumer to call with matched intervals.
+     */
+    public void getIntervals(final int attributeValue, @Nullable final BEInputAttributeCategory matchedInput, @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        throw new UnsupportedOperationException("Cowardly refusal to risk loosing precision");
+    }
+
+    /**
+     * Get intervals matching the specified attribute value.
+     *
+     * @param attributeValue
+     *         Attribute value to get intervals for.
      * @param consumer
      *         Consumer to call with matched intervals.
      */
@@ -93,10 +139,40 @@ public abstract class BEIndexAttributeCategory implements Serializable
      *
      * @param attributeValue
      *         Attribute value to get intervals for.
+     * @param matchedInput
+     *         If tracking is enabled, contains the attribute category and value metadata to use for tracking matched inputs.
+     * @param consumer
+     *         Consumer to call with matched intervals.
+     */
+    public void getIntervals(final long attributeValue, @Nullable final BEInputAttributeCategory matchedInput, @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        throw new UnsupportedOperationException("Cowardly refusal to risk loosing precision");
+    }
+
+    /**
+     * Get intervals matching the specified attribute value.
+     *
+     * @param attributeValue
+     *         Attribute value to get intervals for.
      * @param consumer
      *         Consumer to call with matching intervals.
      */
     public abstract void getIntervals(@Nonnull String attributeValue, @Nonnull Consumer<List<BEInterval>> consumer);
+
+    /**
+     * Get intervals matching the specified attribute value.
+     *
+     * @param attributeValue
+     *         Attribute value to get intervals for.
+     * @param matchedInput
+     *         If tracking is enabled, contains the attribute category and value metadata to use for tracking matched inputs.
+     * @param consumer
+     *         Consumer to call with matching intervals.
+     */
+    public abstract void getIntervals(
+            @Nonnull String attributeValue,
+            @Nullable BEInputAttributeCategory matchedInput,
+            @Nonnull BEAttributeCategoryMatchedIntervalConsumer consumer);
 
     /**
      * Minimize the amount of memory used by the index
@@ -115,6 +191,17 @@ public abstract class BEIndexAttributeCategory implements Serializable
         if (null != intervals)
         {
             consumer.accept(intervals);
+        }
+    }
+
+    protected void callConsumer(
+            @Nullable final List<BEInterval> intervals,
+            @Nullable final BEInputAttributeCategory matchedInput,
+            @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        if (null != intervals)
+        {
+            consumer.accept(matchedInput, intervals);
         }
     }
 }

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEIndexExpressionResult.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEIndexExpressionResult.java
@@ -74,25 +74,28 @@ public class BEIndexExpressionResult implements BEExpressionMetadata, Serializab
         return this.matchedBits;
     }
 
-    void addInterval(final BEInterval interval, final BEInputAttributeCategory matchedInputValues)
+    void addInterval(
+            final BEInterval interval,
+            final BEInputAttributeCategory matchedInputValues,
+            final BEIndexExpressionResult partialExpressionResult)
     {
         final int intervalId = interval.getIntervalId();
-        final BEMatchedInterval matchedInterval = this.matchedIntervals.get(intervalId);
+        BEMatchedInterval matchedInterval = this.matchedIntervals.get(intervalId);
         if (matchedInterval == null)
         {
             // Create a matched interval from the raw interval and add it to the matched intervals for this expression
-            final BEMatchedInterval newMatchedInterval = new BEMatchedInterval(interval);
-            newMatchedInterval.addMatchedInputValues(matchedInputValues);
+            final BEMatchedInterval newMatchedInterval = new BEMatchedInterval(interval, partialExpressionResult != null);
             this.matchedIntervals.put(intervalId, newMatchedInterval);
             if (this.useBitSetMatching)
             {
                 this.matchedBits.or(interval.getBits());
             }
-        } else
-        {
-            // Update matched interval with new input
-            matchedInterval.addMatchedInputValues(matchedInputValues);
+            matchedInterval = newMatchedInterval;
         }
-    }
 
+        // Update matched interval with new input
+        matchedInterval.addMatchedInputValues(matchedInputValues);
+        matchedInterval.setPartialExpressionIndexResult(partialExpressionResult);
+
+    }
 }

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEIndexExpressionResult.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEIndexExpressionResult.java
@@ -1,6 +1,10 @@
 package com.amobee.freebee.evaluator.index;
 
 import com.amobee.freebee.evaluator.BEInterval;
+import com.amobee.freebee.evaluator.BEMatchedInterval;
+import com.amobee.freebee.evaluator.evaluator.BEInputAttributeCategory;
+import org.eclipse.collections.api.map.primitive.MutableIntObjectMap;
+import org.eclipse.collections.impl.factory.primitive.IntObjectMaps;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -19,14 +23,14 @@ public class BEIndexExpressionResult implements BEExpressionMetadata, Serializab
 
     private final BEExpressionMetadata expressionMetadata;
     private final boolean useBitSetMatching;
-    private final List<BEInterval> matchedIntervals;
+    private final MutableIntObjectMap<BEMatchedInterval> matchedIntervals;
     private final BitSet matchedBits;
 
     BEIndexExpressionResult(final BEExpressionMetadata metadata)
     {
         this.expressionMetadata = metadata;
         this.useBitSetMatching = metadata.canUseBitSetMatching();
-        this.matchedIntervals = this.useBitSetMatching ? null : new ArrayList<>();
+        this.matchedIntervals = IntObjectMaps.mutable.empty();
         this.matchedBits = this.useBitSetMatching ? new BitSet() : null;
     }
 
@@ -60,9 +64,9 @@ public class BEIndexExpressionResult implements BEExpressionMetadata, Serializab
         return this.expressionMetadata.getPartialExpressionName();
     }
 
-    public List<BEInterval> getMatchedIntervals()
+    public List<BEMatchedInterval> getMatchedIntervals()
     {
-        return this.matchedIntervals;
+        return new ArrayList<>(this.matchedIntervals.values());
     }
 
     public BitSet getMatchedBits()
@@ -70,15 +74,24 @@ public class BEIndexExpressionResult implements BEExpressionMetadata, Serializab
         return this.matchedBits;
     }
 
-    void addInterval(final BEInterval interval)
+    void addInterval(final BEInterval interval, final BEInputAttributeCategory matchedInputValues)
     {
-        if (this.useBitSetMatching)
+        final int intervalId = interval.getIntervalId();
+        final BEMatchedInterval matchedInterval = this.matchedIntervals.get(intervalId);
+        if (matchedInterval == null)
         {
-            this.matchedBits.or(interval.getBits());
-        }
-        else
+            // Create a matched interval from the raw interval and add it to the matched intervals for this expression
+            final BEMatchedInterval newMatchedInterval = new BEMatchedInterval(interval);
+            newMatchedInterval.addMatchedInputValues(matchedInputValues);
+            this.matchedIntervals.put(intervalId, newMatchedInterval);
+            if (this.useBitSetMatching)
+            {
+                this.matchedBits.or(interval.getBits());
+            }
+        } else
         {
-            this.matchedIntervals.add(interval);
+            // Update matched interval with new input
+            matchedInterval.addMatchedInputValues(matchedInputValues);
         }
     }
 

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEIndexResults.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEIndexResults.java
@@ -37,15 +37,18 @@ public class BEIndexResults
 
     public void addInterval(@Nonnull final BEInterval interval)
     {
-        addInterval(interval, null);
+        addInterval(interval, null, null);
     }
 
-    public void addInterval(@Nonnull final BEInterval interval, @Nullable final BEInputAttributeCategory matchedInputValue)
+    public void addInterval(
+            @Nonnull final BEInterval interval,
+            @Nullable final BEInputAttributeCategory matchedInputValue,
+            @Nullable final BEIndexExpressionResult partialExpressionResult)
     {
         final int exprId = interval.getExpressionId();
         this.indexExpressionResults
                 .getIfAbsentPut(exprId, createExpressionIndexResultBuilder(exprId))
-                .addInterval(interval, matchedInputValue);
+                .addInterval(interval, matchedInputValue, partialExpressionResult);
     }
 
     private BEIndexExpressionResult createExpressionIndexResultBuilder(final int expressionId)

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEIndexResults.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEIndexResults.java
@@ -4,7 +4,9 @@ import com.amobee.freebee.evaluator.BEInterval;
 
 import java.util.Collection;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
+import com.amobee.freebee.evaluator.evaluator.BEInputAttributeCategory;
 import org.eclipse.collections.api.map.primitive.MutableIntObjectMap;
 import org.eclipse.collections.impl.factory.primitive.IntObjectMaps;
 
@@ -35,10 +37,15 @@ public class BEIndexResults
 
     public void addInterval(@Nonnull final BEInterval interval)
     {
+        addInterval(interval, null);
+    }
+
+    public void addInterval(@Nonnull final BEInterval interval, @Nullable final BEInputAttributeCategory matchedInputValue)
+    {
         final int exprId = interval.getExpressionId();
         this.indexExpressionResults
                 .getIfAbsentPut(exprId, createExpressionIndexResultBuilder(exprId))
-                .addInterval(interval);
+                .addInterval(interval, matchedInputValue);
     }
 
     private BEIndexExpressionResult createExpressionIndexResultBuilder(final int expressionId)

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEIntIndexAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEIntIndexAttributeCategory.java
@@ -2,12 +2,14 @@ package com.amobee.freebee.evaluator.index;
 
 import com.amobee.freebee.config.BEDataTypeConfig;
 import com.amobee.freebee.evaluator.BEInterval;
+import com.amobee.freebee.evaluator.evaluator.BEInputAttributeCategory;
 import lombok.Getter;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.eclipse.collections.api.map.primitive.MutableIntObjectMap;
 import org.eclipse.collections.impl.factory.primitive.IntObjectMaps;
@@ -48,15 +50,40 @@ public class BEIntIndexAttributeCategory extends BEIndexAttributeCategory implem
     }
 
     @Override
+    public void getIntervals(final byte attributeValue,
+                             @Nullable final BEInputAttributeCategory matchedInput,
+                             @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        callConsumer(this.values.get(attributeValue), matchedInput, consumer);
+    }
+
+    @Override
     public void getIntervals(final int attributeValue, @Nonnull final Consumer<List<BEInterval>> consumer)
     {
         callConsumer(this.values.get(attributeValue), consumer);
     }
 
     @Override
+    public void getIntervals(final int attributeValue,
+                             @Nullable final BEInputAttributeCategory matchedInput,
+                             @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        callConsumer(this.values.get(attributeValue), matchedInput, consumer);
+    }
+
+    @Override
     public void getIntervals(@Nonnull final String attributeValue, @Nonnull final Consumer<List<BEInterval>> consumer)
     {
         callConsumer(this.values.get(Integer.parseInt(attributeValue)), consumer);
+    }
+
+    @Override
+    public void getIntervals(
+            @Nonnull final String attributeValue,
+            @Nullable final BEInputAttributeCategory matchedInput,
+            @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        callConsumer(this.values.get(Integer.parseInt(attributeValue)), matchedInput, consumer);
     }
 
     @Override

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BELongIndexAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BELongIndexAttributeCategory.java
@@ -2,12 +2,14 @@ package com.amobee.freebee.evaluator.index;
 
 import com.amobee.freebee.config.BEDataTypeConfig;
 import com.amobee.freebee.evaluator.BEInterval;
+import com.amobee.freebee.evaluator.evaluator.BEInputAttributeCategory;
 import lombok.Getter;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.eclipse.collections.api.map.primitive.MutableLongObjectMap;
 import org.eclipse.collections.impl.factory.primitive.LongObjectMaps;
@@ -48,9 +50,25 @@ public class BELongIndexAttributeCategory extends BEIndexAttributeCategory imple
     }
 
     @Override
+    public void getIntervals(final byte attributeValue,
+                             @Nullable final BEInputAttributeCategory matchedInput,
+                             @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        callConsumer(this.values.get(attributeValue), matchedInput, consumer);
+    }
+
+    @Override
     public void getIntervals(final int attributeValue, @Nonnull final Consumer<List<BEInterval>> consumer)
     {
         callConsumer(this.values.get(attributeValue), consumer);
+    }
+
+    @Override
+    public void getIntervals(final int attributeValue,
+                             @Nullable final BEInputAttributeCategory matchedInput,
+                             @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        callConsumer(this.values.get(attributeValue), matchedInput, consumer);
     }
 
     @Override
@@ -60,9 +78,26 @@ public class BELongIndexAttributeCategory extends BEIndexAttributeCategory imple
     }
 
     @Override
+    public void getIntervals(final long attributeValue,
+                             @Nullable final BEInputAttributeCategory matchedInput,
+                             @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        callConsumer(this.values.get(attributeValue), matchedInput, consumer);
+    }
+
+    @Override
     public void getIntervals(@Nonnull final String attributeValue, @Nonnull final Consumer<List<BEInterval>> consumer)
     {
         callConsumer(this.values.get(Long.parseLong(attributeValue)), consumer);
+    }
+
+    @Override
+    public void getIntervals(
+            @Nonnull final String attributeValue,
+            @Nullable final BEInputAttributeCategory matchedInput,
+            @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        callConsumer(this.values.get(Long.parseLong(attributeValue)), matchedInput, consumer);
     }
 
     @Override

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEPartialStringIndexAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEPartialStringIndexAttributeCategory.java
@@ -5,8 +5,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.amobee.freebee.evaluator.BEInterval;
+import com.amobee.freebee.evaluator.evaluator.BEInputAttributeCategory;
 import com.amobee.freebee.util.trie.BitTrie;
 import com.amobee.freebee.util.trie.ReverseStringBitKeyAnalyzer;
 import com.amobee.freebee.util.trie.StringBitKeyAnalyzer;
@@ -45,6 +47,16 @@ public class BEPartialStringIndexAttributeCategory extends BEAbstractStringIndex
     public void getIntervals(@Nonnull final String attributeValue, @Nonnull final Consumer<List<BEInterval>> consumer)
     {
         this.values.getAll(getValue(attributeValue), entry -> consumer.accept(entry.getValue()));
+    }
+
+    @Override
+    public void getIntervals(
+            @Nonnull final String attributeValue,
+            @Nullable final BEInputAttributeCategory matchedInput,
+            @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+
+        this.values.getAll(getValue(attributeValue), entry -> consumer.accept(matchedInput, entry.getValue()));
     }
 
     public Trie<String, List<BEInterval>> getValues()

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEStringIndexAttributeCategory.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/index/BEStringIndexAttributeCategory.java
@@ -2,12 +2,14 @@ package com.amobee.freebee.evaluator.index;
 
 import com.amobee.freebee.config.BEDataTypeConfig;
 import com.amobee.freebee.evaluator.BEInterval;
+import com.amobee.freebee.evaluator.evaluator.BEInputAttributeCategory;
 import lombok.Getter;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.factory.Maps;
@@ -55,6 +57,15 @@ public class BEStringIndexAttributeCategory extends BEAbstractStringIndexAttribu
     public void getIntervals(@Nonnull final String attributeValue, @Nonnull final Consumer<List<BEInterval>> consumer)
     {
         callConsumer(this.values.get(getValue(attributeValue)), consumer);
+    }
+
+    @Override
+    public void getIntervals(
+            @Nonnull final String attributeValue,
+            @Nullable final BEInputAttributeCategory matchedInput,
+            @Nonnull final BEAttributeCategoryMatchedIntervalConsumer consumer)
+    {
+        callConsumer(this.values.get(getValue(attributeValue)), matchedInput, consumer);
     }
 
     @Override

--- a/freebee-core/src/main/java/com/amobee/freebee/evaluator/interval/BESimpleInterval.java
+++ b/freebee-core/src/main/java/com/amobee/freebee/evaluator/interval/BESimpleInterval.java
@@ -54,7 +54,7 @@ final class BESimpleInterval implements Interval, Serializable
     @Override
     public String toString()
     {
-        return "BESimpleInterval[" + start + "," + end + ')';
+        return "BESimpleInterval[" + this.start + "," + this.end + ')';
     }
 
     @Override

--- a/freebee-core/src/test/java/com/amobee/freebee/evaluator/evaluator/BEEvaluatorTest.java
+++ b/freebee-core/src/test/java/com/amobee/freebee/evaluator/evaluator/BEEvaluatorTest.java
@@ -15,11 +15,13 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -206,13 +208,14 @@ public class BEEvaluatorTest
         assertTrue("D2", matchedExpressions.contains("D2"));
         assertTrue("AR2 and D2", matchedExpressions.contains("AR2 and D2"));
         assertTrue("AR2 or D2", matchedExpressions.contains("AR2 or D2"));
-        assertThat(result.getPossibleInputValuesThatSatisfy("AR2")).isEmpty();
+        assertThat(result.getPossibleInputValuesThatSatisfy("AR2"))
+                .containsExactly(emptyList());
         assertThat(result.getPossibleInputValuesThatSatisfy("D2"))
                 .containsExactly(singletonList(input("domain", "gooddomain.com")));
         assertThat(result.getPossibleInputValuesThatSatisfy("AR2 and D2"))
                 .containsExactly(asList(input("domain", "gooddomain.com")));
         assertThat(result.getPossibleInputValuesThatSatisfy("AR2 or D2"))
-                .containsExactly(asList(input("domain", "gooddomain.com")));
+                .containsExactly(emptyList(), asList(input("domain", "gooddomain.com")));
 
         input = new BEInput();
         input.getOrCreateStringCategory("age").setTrackingEnabled(false);
@@ -228,10 +231,10 @@ public class BEEvaluatorTest
         assertFalse("D2", matchedExpressions.contains("D2"));
         assertFalse("AR2 and D2", matchedExpressions.contains("AR2 and D2"));
         assertTrue("AR2 or D2", matchedExpressions.contains("AR2 or D2"));
-        assertThat(result.getPossibleInputValuesThatSatisfy("AR2")).isEmpty();
+        assertThat(result.getPossibleInputValuesThatSatisfy("AR2")).containsExactly(emptyList());
         assertThat(result.getPossibleInputValuesThatSatisfy("D2")).isNull();
         assertThat(result.getPossibleInputValuesThatSatisfy("AR2 and D2")).isNull();
-        assertThat(result.getPossibleInputValuesThatSatisfy("AR2 or D2")).isEmpty();
+        assertThat(result.getPossibleInputValuesThatSatisfy("AR2 or D2")).containsExactly(emptyList());
 
         input = new BEInput();
         input.getOrCreateStringCategory("age").setTrackingEnabled(false);
@@ -264,13 +267,13 @@ public class BEEvaluatorTest
         assertTrue("D2", matchedExpressions.contains("D2"));
         assertTrue("AR2 and D2", matchedExpressions.contains("AR2 and D2"));
         assertTrue("AR2 or D2", matchedExpressions.contains("AR2 or D2"));
-        assertThat(result.getPossibleInputValuesThatSatisfy("AR2")).isEmpty();
+        assertThat(result.getPossibleInputValuesThatSatisfy("AR2")).containsExactly(emptyList());
         assertThat(result.getPossibleInputValuesThatSatisfy("D2"))
                 .containsExactly(singletonList(input("domain", "gooddomain.com", "gooddomain2.com")));
         assertThat(result.getPossibleInputValuesThatSatisfy("AR2 and D2"))
                 .containsExactly(asList(input("domain", "gooddomain.com", "gooddomain2.com")));
         assertThat(result.getPossibleInputValuesThatSatisfy("AR2 or D2"))
-                .containsExactly(asList(input("domain", "gooddomain.com", "gooddomain2.com")));
+                .containsExactly(emptyList(), asList(input("domain", "gooddomain.com", "gooddomain2.com")));
 
         input = new BEInput();
         input.getOrCreateStringCategory("age").setTrackingEnabled(false);
@@ -287,13 +290,13 @@ public class BEEvaluatorTest
         assertTrue("D2", matchedExpressions.contains("D2"));
         assertTrue("AR2 and D2", matchedExpressions.contains("AR2 and D2"));
         assertTrue("AR2 or D2", matchedExpressions.contains("AR2 or D2"));
-        assertThat(result.getPossibleInputValuesThatSatisfy("AR2")).isEmpty();
+        assertThat(result.getPossibleInputValuesThatSatisfy("AR2")).containsExactly(emptyList());
         assertThat(result.getPossibleInputValuesThatSatisfy("D2"))
                 .containsExactly(singletonList(input("domain", "gooddomain.com")));
         assertThat(result.getPossibleInputValuesThatSatisfy("AR2 and D2"))
                 .containsExactly(asList(input("domain", "gooddomain.com")));
         assertThat(result.getPossibleInputValuesThatSatisfy("AR2 or D2"))
-                .containsExactly(asList(input("domain", "gooddomain.com")));
+                .containsExactly(emptyList(), asList(input("domain", "gooddomain.com")));
 
         input = new BEInput();
         input.getOrCreateStringCategory("age").setTrackingEnabled(false);
@@ -310,10 +313,10 @@ public class BEEvaluatorTest
         assertFalse("D2", matchedExpressions.contains("D2"));
         assertFalse("AR2 and D2", matchedExpressions.contains("AR2 and D2"));
         assertTrue("AR2 or D2", matchedExpressions.contains("AR2 or D2"));
-        assertThat(result.getPossibleInputValuesThatSatisfy("AR2")).isEmpty();
+        assertThat(result.getPossibleInputValuesThatSatisfy("AR2")).containsExactly(emptyList());
         assertThat(result.getPossibleInputValuesThatSatisfy("D2")).isNull();
         assertThat(result.getPossibleInputValuesThatSatisfy("AR2 and D2")).isNull();
-        assertThat(result.getPossibleInputValuesThatSatisfy("AR2 or D2")).isEmpty();
+        assertThat(result.getPossibleInputValuesThatSatisfy("AR2 or D2")).containsExactly(emptyList());
 
         input = new BEInput();
         input.getOrCreateStringCategory("age").setTrackingEnabled(false);
@@ -330,10 +333,10 @@ public class BEEvaluatorTest
         assertFalse("D2", matchedExpressions.contains("D2"));
         assertFalse("AR2 and D2", matchedExpressions.contains("AR2 and D2"));
         assertTrue("AR2 or D2", matchedExpressions.contains("AR2 or D2"));
-        assertThat(result.getPossibleInputValuesThatSatisfy("AR2")).isEmpty();
+        assertThat(result.getPossibleInputValuesThatSatisfy("AR2")).containsExactly(emptyList());
         assertThat(result.getPossibleInputValuesThatSatisfy("D2")).isNull();
         assertThat(result.getPossibleInputValuesThatSatisfy("AR2 and D2")).isNull();
-        assertThat(result.getPossibleInputValuesThatSatisfy("AR2 or D2")).isEmpty();
+        assertThat(result.getPossibleInputValuesThatSatisfy("AR2 or D2")).containsExactly(emptyList());
 
         input = new BEInput();
         input.getOrCreateStringCategory("age").setTrackingEnabled(false);
@@ -2116,28 +2119,44 @@ public class BEEvaluatorTest
         builder.addDataTypeConfig(DATA_TYPE_CONFIG);
         builder.addPartialExpression("dg:1", "{\"type\":\"domain\",\"values\":[{\"id\":\".videologygroup.com\"}]}");
         builder.addPartialExpression("ag:1", "{\"type\":\"age\",\"values\":[{\"id\":\"[18,24)\"}]}");
-        builder.addExpression("test1", "{\"type\":\"and\",\"values\":[{\"type\":\"ref\",\"values\":[{\"id\":\"dg:1\"}]},{\"type\":\"gender\",\"values\":[{\"id\":\"M\"}]}]}");
-        builder.addExpression("test2", "{\"type\":\"and\",\"values\":[{\"type\":\"ref\",\"values\":[{\"id\":\"dg:1\"}]},{\"type\":\"ref\",\"values\":[{\"id\":\"ag:1\"}]},{\"type\":\"gender\",\"values\":[{\"id\":\"F\"}]}]}");
+        builder.addExpression("D and G1", "{\"type\":\"and\",\"values\":[{\"type\":\"ref\",\"values\":[{\"id\":\"dg:1\"}]},{\"type\":\"gender\",\"values\":[{\"id\":\"M\"}]}]}");
+        builder.addExpression("D and A and G2", "{\"type\":\"and\",\"values\":[{\"type\":\"ref\",\"values\":[{\"id\":\"dg:1\"}]},{\"type\":\"ref\",\"values\":[{\"id\":\"ag:1\"}]},{\"type\":\"gender\",\"values\":[{\"id\":\"F\"}]}]}");
 
         final BEEvaluator<String> evaluator = builder.build();
 
-        BEInput input = new BEInput();
-        input.getOrCreateStringCategory("domain").add("www.videologygroup.com");
-        input.getOrCreateStringCategory("age").add("[18,24)");
-        input.getOrCreateStringCategory("gender").add("M");
-
-        Set<String> result = evaluator.evaluate(input);
-        assertEquals(1, result.size());
-        assertTrue("test1", result.contains("test1"));
+        BEInput input;
+        BEEvaluatorResult<String> result;
+        Set<String> matchedExpressions;
 
         input = new BEInput();
+        input.getOrCreateStringCategory("domain").setTrackingEnabled(true);
         input.getOrCreateStringCategory("domain").add("www.videologygroup.com");
+        input.getOrCreateStringCategory("age").setTrackingEnabled(false);
         input.getOrCreateStringCategory("age").add("[18,24)");
+        input.getOrCreateStringCategory("gender").setTrackingEnabled(true);
+        input.getOrCreateStringCategory("gender").add("M");
+
+//        result = evaluator.evaluateAndTrack(input);
+//        matchedExpressions = result.getMatchedExpressions();
+//        assertEquals(1, matchedExpressions.size());
+//        assertTrue("D and G1", matchedExpressions.contains("D and G1"));
+//        assertThat(result.getPossibleInputValuesThatSatisfy("D and G1")).containsExactly(
+//                asList(input.getCategory("domain"), input.getCategory("gender")));
+
+        input = new BEInput();
+        input.getOrCreateStringCategory("domain").setTrackingEnabled(true);
+        input.getOrCreateStringCategory("domain").add("www.videologygroup.com");
+        input.getOrCreateStringCategory("age").setTrackingEnabled(false);
+        input.getOrCreateStringCategory("age").add("[18,24)");
+        input.getOrCreateStringCategory("gender").setTrackingEnabled(true);
         input.getOrCreateStringCategory("gender").add("F");
 
-        result = evaluator.evaluate(input);
-        assertEquals(1, result.size());
-        assertTrue("test2", result.contains("test2"));
+        result = evaluator.evaluateAndTrack(input);
+        matchedExpressions = result.getMatchedExpressions();
+        assertEquals(1, matchedExpressions.size());
+        assertTrue("D and A and G2", matchedExpressions.contains("D and A and G2"));
+        assertThat(result.getPossibleInputValuesThatSatisfy("D and A and G2")).containsExactly(
+                asList(input.getCategory("domain"), input.getCategory("gender")));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -29,13 +29,14 @@
         <commons-lang3.version>3.9</commons-lang3.version>
         <eclipse-collections.version>10.0.0</eclipse-collections.version>
         <findbugs.version>3.0.1</findbugs.version>
-        <guava.version>20.0</guava.version>
-        <jackson.version>2.8.1</jackson.version>
+        <guava.version>24.1.1-jre</guava.version>
+        <jackson.version>2.8.11</jackson.version>
         <joda.version>2.8.1</joda.version>
         <lombok.version>1.18.2</lombok.version>
         <slf4j.version>1.7.21</slf4j.version>
         <!-- Test Dependency Versions-->
-        <junit.version>4.12</junit.version>
+        <junit.version> 4.13.2</junit.version>
+        <assertj.version>3.22.0</assertj.version>
     </properties>
 
     <build>
@@ -195,6 +196,12 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
Initial implementation of possible method for tracking input values used to satisfy a boolean expression when running the BE evaluator for a given input.

Quick how to for this pull request:

```java
final BEEvaluatorBuilder<String> builder = new BEEvaluatorBuilder<>();
builder.addDataTypeConfig(DATA_TYPE_CONFIG);

builder.addExpression("(A and B) or C or (D and E and F)", /*...*/);
final BEEvaluator<String> evaluator = builder.build();

BEInput input;
BEEvaluatorResult<String> result;
Set<String> matchedExpressions;

// match due to C or D,E,F
input = new BEInput();
input.getOrCreateStringCategory("testCategory").setTrackingEnabled(true);
input.getOrCreateStringCategory("testCategory").add("C");
input.getOrCreateStringCategory("testCategory").add("D");
input.getOrCreateStringCategory("testCategory").add("E");
input.getOrCreateStringCategory("testCategory").add("F");

result = evaluateAndTrack(input);
matchedExpressions = result.getMatchedExpressions();
result.getPossibleInputValuesThatSatisfy("(A and B) or C or (D and E and F)"));
// Returns:
//
//  [
//      [
//         BEStringInputAttributeCategory(name=testCategory, values=[C])
//      ],
//      [
//         BEStringInputAttributeCategory(name=testCategory, values=[D]),
//         BEStringInputAttributeCategory(name=testCategory, values=[E]),
//         BEStringInputAttributeCategory(name=testCategory, values=[F])
//      ]
//  ]
```

For more examples, see `BEEvaluatorTest`.

See JavaDoc for new BEEvaluatorResult object:

```java
/**
 * Returns the possible combinations of input values that could satisfy a given expression.
 *
 * Input values are returned as 2D list, ie a list of lists.
 * Each row in the outer list represents one possible way to satisfy the overall expression.
 * Each inner list represents the input attribute category values required to fulfil the expression.
 * For each attribute category entry in the inner list, one value must be used for the overall expression to be satisfied.
 *
 * Put another way: For the outer list, choose any row/entry. For the inner list for that selection,
 * chose one value from every BEInputAttributeCategory in the list.
 *
 * Note: Input attribute categories and values are only returned if tracking is enabled when creating the input
 * attribute category. Untracked categories will not appear at all in the return values of this method.
 */
public List<List<? extends BEInputAttributeCategory>> getPossibleInputValuesThatSatisfy(final T expressionData)
```

Notes:

- In testing, performance impact is minimal (~1ms) for small to medium expressions / inputs with up to 100 attribute values in a tracked attribute category. But performance impact grows as the number of tracked attribute values increases.
- Tracking *has* to be enabled for the desired Input attribute category, and will only be enabled for the specified categories.
- This implementation does not yet support value tracking for referenced partial expressions. That could probably be added if the general approach and interface is suitable.